### PR TITLE
Fixes retry loop caused by not incrementing retry counter.

### DIFF
--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ActualMeterReadsResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ActualMeterReadsResponseMessageProcessor.java
@@ -14,9 +14,13 @@ import com.alliander.osgp.adapter.domain.smartmetering.application.services.Moni
 import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreResponseMessageProcessor;
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
 import com.alliander.osgp.dto.valueobjects.smartmetering.ActualMeterReads;
+import com.alliander.osgp.dto.valueobjects.smartmetering.ActualMeterReadsQuery;
 import com.alliander.osgp.dto.valueobjects.smartmetering.MeterReadsGas;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
+import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 @Component("domainSmartMeteringActualMeterReadsResponseMessageProcessor")
 public class ActualMeterReadsResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
@@ -38,11 +42,34 @@ public class ActualMeterReadsResponseMessageProcessor extends OsgpCoreResponseMe
 
             this.monitoringService.handleActualMeterReadsResponse(deviceIdentification, organisationIdentification,
                     correlationUid, messageType, responseMessage.getResult(), osgpException, actualMeterReadsDto);
-        } else {
+        } else if (responseMessage.getDataObject() instanceof MeterReadsGas) {
             final MeterReadsGas meterReadsGas = (MeterReadsGas) responseMessage.getDataObject();
             this.monitoringService.handleActualMeterReadsResponse(deviceIdentification, organisationIdentification,
                     correlationUid, messageType, responseMessage.getResult(), osgpException, meterReadsGas);
+        } else if (responseMessage.getDataObject() instanceof ActualMeterReadsQuery) {
+            final OsgpException e;
+            if (osgpException == null) {
+                e = new TechnicalException(ComponentType.DOMAIN_SMART_METERING, "Error retrieving actual meter reads.",
+                        null);
+            } else {
+                e = osgpException;
+            }
+            if (((ActualMeterReadsQuery) responseMessage.getDataObject()).isGas()) {
+                this.monitoringService.handleActualMeterReadsResponse(deviceIdentification, organisationIdentification,
+                        correlationUid, messageType, ResponseMessageResultType.NOT_OK, e, (MeterReadsGas) null);
+            } else {
+                this.monitoringService.handleActualMeterReadsResponse(deviceIdentification, organisationIdentification,
+                        correlationUid, messageType, ResponseMessageResultType.NOT_OK, e, (ActualMeterReads) null);
+            }
+        } else if (osgpException == null) {
+            this.monitoringService.handleActualMeterReadsResponse(deviceIdentification, organisationIdentification,
+                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, new TechnicalException(
+                            ComponentType.DOMAIN_SMART_METERING, "Error retrieving actual meter reads.", null),
+                    (ActualMeterReads) null);
+        } else {
+            this.monitoringService.handleActualMeterReadsResponse(deviceIdentification, organisationIdentification,
+                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, osgpException,
+                    (ActualMeterReads) null);
         }
     }
-
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/AddMeterResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/AddMeterResponseMessageProcessor.java
@@ -30,6 +30,12 @@ public class AddMeterResponseMessageProcessor extends OsgpCoreResponseMessagePro
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        // Only the result is used, no need to check the dataObject.
+        return true;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/FindEventsResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/FindEventsResponseMessageProcessor.java
@@ -30,6 +30,11 @@ public class FindEventsResponseMessageProcessor extends OsgpCoreResponseMessageP
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        return responseMessage.getDataObject() instanceof EventMessageDataContainer;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAdministrativeStateResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAdministrativeStateResponseMessageProcessor.java
@@ -14,8 +14,11 @@ import com.alliander.osgp.adapter.domain.smartmetering.application.services.Conf
 import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreResponseMessageProcessor;
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
 import com.alliander.osgp.dto.valueobjects.smartmetering.AdministrativeStatusType;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
+import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 @Component("domainSmartMeteringGetAdministrativeStateResponseMessageProcessor")
 public class GetAdministrativeStateResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
@@ -32,10 +35,21 @@ public class GetAdministrativeStateResponseMessageProcessor extends OsgpCoreResp
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {
 
-        final AdministrativeStatusType administrativeStatusTypeDto = (AdministrativeStatusType) responseMessage
-                .getDataObject();
-        this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
-                organisationIdentification, correlationUid, messageType, responseMessage.getResult(), osgpException,
-                administrativeStatusTypeDto);
+        if (responseMessage.getDataObject() instanceof AdministrativeStatusType) {
+            final AdministrativeStatusType administrativeStatusTypeDto = (AdministrativeStatusType) responseMessage
+                    .getDataObject();
+            this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
+                    organisationIdentification, correlationUid, messageType, responseMessage.getResult(),
+                    osgpException, administrativeStatusTypeDto);
+        } else if (osgpException == null) {
+            this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
+                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
+                    new TechnicalException(ComponentType.DOMAIN_SMART_METERING,
+                            "Error retrieving administrative status.", null), (AdministrativeStatusType) null);
+        } else {
+            this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
+                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
+                    osgpException, (AdministrativeStatusType) null);
+        }
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAdministrativeStateResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAdministrativeStateResponseMessageProcessor.java
@@ -14,11 +14,8 @@ import com.alliander.osgp.adapter.domain.smartmetering.application.services.Conf
 import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreResponseMessageProcessor;
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
 import com.alliander.osgp.dto.valueobjects.smartmetering.AdministrativeStatusType;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
-import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 @Component("domainSmartMeteringGetAdministrativeStateResponseMessageProcessor")
 public class GetAdministrativeStateResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
@@ -31,25 +28,19 @@ public class GetAdministrativeStateResponseMessageProcessor extends OsgpCoreResp
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        return responseMessage.getDataObject() instanceof AdministrativeStatusType;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {
 
-        if (responseMessage.getDataObject() instanceof AdministrativeStatusType) {
-            final AdministrativeStatusType administrativeStatusTypeDto = (AdministrativeStatusType) responseMessage
-                    .getDataObject();
-            this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
-                    organisationIdentification, correlationUid, messageType, responseMessage.getResult(),
-                    osgpException, administrativeStatusTypeDto);
-        } else if (osgpException == null) {
-            this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
-                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
-                    new TechnicalException(ComponentType.DOMAIN_SMART_METERING,
-                            "Error retrieving administrative status.", null), (AdministrativeStatusType) null);
-        } else {
-            this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
-                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
-                    osgpException, (AdministrativeStatusType) null);
-        }
+        final AdministrativeStatusType administrativeStatusTypeDto = (AdministrativeStatusType) responseMessage
+                .getDataObject();
+        this.configurationService.handleGetAdministrativeStatusResponse(deviceIdentification,
+                organisationIdentification, correlationUid, messageType, responseMessage.getResult(), osgpException,
+                administrativeStatusTypeDto);
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/PeriodicMeterReadsresponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/PeriodicMeterReadsresponseMessageProcessor.java
@@ -16,12 +16,8 @@ import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreRe
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
 import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsContainer;
 import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsContainerGas;
-import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsQuery;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
-import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 @Component("domainSmartMeteringPeriodicMeterReadsResponseMessageProcessor")
 public class PeriodicMeterReadsresponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
@@ -32,6 +28,13 @@ public class PeriodicMeterReadsresponseMessageProcessor extends OsgpCoreResponse
 
     protected PeriodicMeterReadsresponseMessageProcessor() {
         super(DeviceFunction.REQUEST_PERIODIC_METER_DATA);
+    }
+
+    @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        final Object dataObject = responseMessage.getDataObject();
+        return dataObject instanceof PeriodicMeterReadsContainer
+                || dataObject instanceof PeriodicMeterReadsContainerGas;
     }
 
     @Override
@@ -53,32 +56,6 @@ public class PeriodicMeterReadsresponseMessageProcessor extends OsgpCoreResponse
             this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification, organisationIdentification,
                     correlationUid, messageType, responseMessage.getResult(), osgpException,
                     periodicMeterReadsContainerGas);
-        } else if (responseMessage.getDataObject() instanceof PeriodicMeterReadsQuery) {
-            final OsgpException e;
-            if (osgpException == null) {
-                e = new TechnicalException(ComponentType.DOMAIN_SMART_METERING,
-                        "Error retrieving periodic meter reads.", null);
-            } else {
-                e = osgpException;
-            }
-            if (((PeriodicMeterReadsQuery) responseMessage.getDataObject()).isGas()) {
-                this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification,
-                        organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK, e,
-                        (PeriodicMeterReadsContainerGas) null);
-            } else {
-                this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification,
-                        organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK, e,
-                        (PeriodicMeterReadsContainer) null);
-            }
-        } else if (osgpException == null) {
-            this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification, organisationIdentification,
-                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, new TechnicalException(
-                            ComponentType.DOMAIN_SMART_METERING, "Error retrieving periodic meter reads.", null),
-                            (PeriodicMeterReadsContainer) null);
-        } else {
-            this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification, organisationIdentification,
-                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, osgpException,
-                    (PeriodicMeterReadsContainer) null);
         }
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/PeriodicMeterReadsresponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/PeriodicMeterReadsresponseMessageProcessor.java
@@ -16,8 +16,12 @@ import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreRe
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
 import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsContainer;
 import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsContainerGas;
+import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsQuery;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
+import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 @Component("domainSmartMeteringPeriodicMeterReadsResponseMessageProcessor")
 public class PeriodicMeterReadsresponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
@@ -42,13 +46,39 @@ public class PeriodicMeterReadsresponseMessageProcessor extends OsgpCoreResponse
             this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification, organisationIdentification,
                     correlationUid, messageType, responseMessage.getResult(), osgpException,
                     periodicMeterReadsContainer);
-        } else {
+        } else if (responseMessage.getDataObject() instanceof PeriodicMeterReadsContainerGas) {
             final PeriodicMeterReadsContainerGas periodicMeterReadsContainerGas = (PeriodicMeterReadsContainerGas) responseMessage
                     .getDataObject();
 
             this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification, organisationIdentification,
                     correlationUid, messageType, responseMessage.getResult(), osgpException,
                     periodicMeterReadsContainerGas);
+        } else if (responseMessage.getDataObject() instanceof PeriodicMeterReadsQuery) {
+            final OsgpException e;
+            if (osgpException == null) {
+                e = new TechnicalException(ComponentType.DOMAIN_SMART_METERING,
+                        "Error retrieving periodic meter reads.", null);
+            } else {
+                e = osgpException;
+            }
+            if (((PeriodicMeterReadsQuery) responseMessage.getDataObject()).isGas()) {
+                this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification,
+                        organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK, e,
+                        (PeriodicMeterReadsContainerGas) null);
+            } else {
+                this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification,
+                        organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK, e,
+                        (PeriodicMeterReadsContainer) null);
+            }
+        } else if (osgpException == null) {
+            this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification, organisationIdentification,
+                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, new TechnicalException(
+                            ComponentType.DOMAIN_SMART_METERING, "Error retrieving periodic meter reads.", null),
+                            (PeriodicMeterReadsContainer) null);
+        } else {
+            this.monitoringService.handlePeriodicMeterReadsresponse(deviceIdentification, organisationIdentification,
+                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, osgpException,
+                    (PeriodicMeterReadsContainer) null);
         }
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ReadAlarmRegisterResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ReadAlarmRegisterResponseMessageProcessor.java
@@ -14,12 +14,8 @@ import com.alliander.osgp.adapter.domain.smartmetering.application.services.Moni
 import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreResponseMessageProcessor;
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
 import com.alliander.osgp.dto.valueobjects.smartmetering.AlarmRegister;
-import com.alliander.osgp.dto.valueobjects.smartmetering.ReadAlarmRegisterRequest;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
-import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 @Component("domainSmartMeteringReadAlarmRegisterResponseMessageProcessor")
 public class ReadAlarmRegisterResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
@@ -32,32 +28,18 @@ public class ReadAlarmRegisterResponseMessageProcessor extends OsgpCoreResponseM
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        return responseMessage.getDataObject() instanceof AlarmRegister;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {
 
-        if (responseMessage.getDataObject() instanceof AlarmRegister) {
-            final AlarmRegister alarmRegisterDto = (AlarmRegister) responseMessage.getDataObject();
+        final AlarmRegister alarmRegisterDto = (AlarmRegister) responseMessage.getDataObject();
 
-            this.monitoringService.handleReadAlarmRegisterResponse(deviceIdentification, organisationIdentification,
-                    correlationUid, messageType, responseMessage.getResult(), osgpException, alarmRegisterDto);
-        } else if (responseMessage.getDataObject() instanceof ReadAlarmRegisterRequest) {
-            final OsgpException e;
-            if (osgpException == null) {
-                e = new TechnicalException(ComponentType.DOMAIN_SMART_METERING, "Error reading alarm register.", null);
-            } else {
-                e = osgpException;
-            }
-            this.monitoringService.handleReadAlarmRegisterResponse(deviceIdentification, organisationIdentification,
-                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, e, (AlarmRegister) null);
-        } else if (osgpException == null) {
-            this.monitoringService.handleReadAlarmRegisterResponse(deviceIdentification, organisationIdentification,
-                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, new TechnicalException(
-                            ComponentType.DOMAIN_SMART_METERING, "Error retrieving alarm register.", null),
-                            (AlarmRegister) null);
-        } else {
-            this.monitoringService.handleReadAlarmRegisterResponse(deviceIdentification, organisationIdentification,
-                    correlationUid, messageType, ResponseMessageResultType.NOT_OK, osgpException, (AlarmRegister) null);
-        }
+        this.monitoringService.handleReadAlarmRegisterResponse(deviceIdentification, organisationIdentification,
+                correlationUid, messageType, responseMessage.getResult(), osgpException, alarmRegisterDto);
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetActivityCalendarResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetActivityCalendarResponseMessageProcessor.java
@@ -13,8 +13,11 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.domain.smartmetering.application.services.ConfigurationService;
 import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreResponseMessageProcessor;
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
+import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 /**
  * Class for processing smart metering set Activity Calendar response messages
@@ -34,9 +37,21 @@ public class SetActivityCalendarResponseMessageProcessor extends OsgpCoreRespons
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {
 
-        final String resultString = (String) responseMessage.getDataObject();
+        if (responseMessage.getDataObject() instanceof String) {
+            final String resultString = (String) responseMessage.getDataObject();
 
-        this.configurationService.handleSetActivityCalendarResponse(deviceIdentification, organisationIdentification,
-                correlationUid, messageType, responseMessage.getResult(), osgpException, resultString);
+            this.configurationService.handleSetActivityCalendarResponse(deviceIdentification,
+                    organisationIdentification, correlationUid, messageType, responseMessage.getResult(),
+                    osgpException, resultString);
+        } else if (osgpException == null) {
+            this.configurationService.handleSetActivityCalendarResponse(deviceIdentification,
+                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
+                    new TechnicalException(ComponentType.DOMAIN_SMART_METERING, "Error setting activity calendar.",
+                            null), (String) null);
+        } else {
+            this.configurationService.handleSetActivityCalendarResponse(deviceIdentification,
+                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
+                    osgpException, (String) null);
+        }
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetActivityCalendarResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetActivityCalendarResponseMessageProcessor.java
@@ -13,11 +13,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.domain.smartmetering.application.services.ConfigurationService;
 import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreResponseMessageProcessor;
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.ResponseMessage;
-import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 
 /**
  * Class for processing smart metering set Activity Calendar response messages
@@ -33,25 +30,18 @@ public class SetActivityCalendarResponseMessageProcessor extends OsgpCoreRespons
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        return responseMessage.getDataObject() instanceof String;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {
 
-        if (responseMessage.getDataObject() instanceof String) {
-            final String resultString = (String) responseMessage.getDataObject();
+        final String resultString = (String) responseMessage.getDataObject();
 
-            this.configurationService.handleSetActivityCalendarResponse(deviceIdentification,
-                    organisationIdentification, correlationUid, messageType, responseMessage.getResult(),
-                    osgpException, resultString);
-        } else if (osgpException == null) {
-            this.configurationService.handleSetActivityCalendarResponse(deviceIdentification,
-                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
-                    new TechnicalException(ComponentType.DOMAIN_SMART_METERING, "Error setting activity calendar.",
-                            null), (String) null);
-        } else {
-            this.configurationService.handleSetActivityCalendarResponse(deviceIdentification,
-                    organisationIdentification, correlationUid, messageType, ResponseMessageResultType.NOT_OK,
-                    osgpException, (String) null);
-        }
+        this.configurationService.handleSetActivityCalendarResponse(deviceIdentification, organisationIdentification,
+                correlationUid, messageType, responseMessage.getResult(), osgpException, resultString);
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAdministrativeStatusResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAdministrativeStatusResponseMessageProcessor.java
@@ -27,6 +27,12 @@ public class SetAdministrativeStatusResponseMessageProcessor extends OsgpCoreRes
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        // Only the result is used, no need to check the dataObject.
+        return true;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAlarmNotificationsResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAlarmNotificationsResponseMessageProcessor.java
@@ -30,6 +30,12 @@ public class SetAlarmNotificationsResponseMessageProcessor extends OsgpCoreRespo
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        // Only the result is used, no need to check the dataObject.
+        return true;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetConfigurationObjectResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetConfigurationObjectResponseMessageProcessor.java
@@ -31,6 +31,12 @@ public class SetConfigurationObjectResponseMessageProcessor extends OsgpCoreResp
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        // Only the result is used, no need to check the dataObject.
+        return true;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SpecialDaysResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SpecialDaysResponseMessageProcessor.java
@@ -31,6 +31,12 @@ public class SpecialDaysResponseMessageProcessor extends OsgpCoreResponseMessage
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        // Only the result is used, no need to check the dataObject.
+        return true;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SynchronizeTimeResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SynchronizeTimeResponseMessageProcessor.java
@@ -31,6 +31,12 @@ public class SynchronizeTimeResponseMessageProcessor extends OsgpCoreResponseMes
     }
 
     @Override
+    protected boolean hasRegularResponseObject(final ResponseMessage responseMessage) {
+        // Only the result is used, no need to check the dataObject.
+        return true;
+    }
+
+    @Override
     protected void handleMessage(final String deviceIdentification, final String organisationIdentification,
             final String correlationUid, final String messageType, final ResponseMessage responseMessage,
             final OsgpException osgpException) {

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringAdhocEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringAdhocEndpoint.java
@@ -62,8 +62,9 @@ public class SmartMeteringAdhocEndpoint extends SmartMeteringEndpoint {
             @OrganisationIdentification final String organisationIdentification,
             @RequestPayload final SynchronizeTimeAsyncRequest request) throws OsgpException {
 
+        SynchronizeTimeResponse response = null;
         try {
-            final SynchronizeTimeResponse response = new SynchronizeTimeResponse();
+            response = new SynchronizeTimeResponse();
             final MeterResponseData meterResponseData = this.adhocService.dequeueSynchronizeTimeResponse(request
                     .getCorrelationUid());
 
@@ -72,9 +73,9 @@ public class SmartMeteringAdhocEndpoint extends SmartMeteringEndpoint {
                 response.setDescription((String) meterResponseData.getMessageData());
             }
 
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 }

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringConfigurationEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringConfigurationEndpoint.java
@@ -52,7 +52,9 @@ import com.alliander.osgp.adapter.ws.smartmetering.application.services.Configur
 import com.alliander.osgp.adapter.ws.smartmetering.domain.entities.MeterResponseData;
 import com.alliander.osgp.domain.core.valueobjects.smartmetering.ActivityCalendar;
 import com.alliander.osgp.domain.core.valueobjects.smartmetering.AlarmNotifications;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
+import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 
 @Endpoint
 public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
@@ -96,8 +98,9 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             @OrganisationIdentification final String organisationIdentification,
             @RequestPayload final SetAdministrativeStatusAsyncRequest request) throws OsgpException {
 
+        SetAdministrativeStatusResponse response = null;
         try {
-            final SetAdministrativeStatusResponse response = new SetAdministrativeStatusResponse();
+            response = new SetAdministrativeStatusResponse();
             final MeterResponseData meterResponseData = this.configurationService
                     .dequeueSetAdministrativeStatusResponse(request.getCorrelationUid());
 
@@ -105,11 +108,10 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             if (meterResponseData.getMessageData() instanceof String) {
                 response.setDescription((String) meterResponseData.getMessageData());
             }
-
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "GetAdministrativeStatusRequest", namespace = SMARTMETER_CONFIGURATION_NAMESPACE)
@@ -136,22 +138,30 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             @OrganisationIdentification final String organisationIdentification,
             @RequestPayload final GetAdministrativeStatusAsyncRequest request) throws OsgpException {
 
+        GetAdministrativeStatusResponse response = null;
         try {
             final MeterResponseData meterResponseData = this.configurationService
                     .dequeueGetAdministrativeStatusResponse(request.getCorrelationUid());
 
-            final GetAdministrativeStatusResponse response = new GetAdministrativeStatusResponse();
+            if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
+                if (meterResponseData.getMessageData() instanceof String) {
+                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
+                            (String) meterResponseData.getMessageData(), null);
+                } else {
+                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
+                            "An exception occurred retrieving the administrative status.", null);
+                }
+            }
+
+            response = new GetAdministrativeStatusResponse();
             final AdministrativeStatusType dataRequest = this.configurationMapper.map(
                     meterResponseData.getMessageData(), AdministrativeStatusType.class);
             response.setEnabled(dataRequest);
 
-            return response;
-
         } catch (final Exception e) {
             this.handleException(e);
         }
-
-        return null;
+        return response;
     }
 
     @PayloadRoot(localPart = "SetSpecialDaysRequest", namespace = SMARTMETER_CONFIGURATION_NAMESPACE)
@@ -180,8 +190,9 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             @OrganisationIdentification final String organisationIdentification,
             @RequestPayload final SetSpecialDaysAsyncRequest request) throws OsgpException {
 
+        SetSpecialDaysResponse response = null;
         try {
-            final SetSpecialDaysResponse response = new SetSpecialDaysResponse();
+            response = new SetSpecialDaysResponse();
             final MeterResponseData meterResponseData = this.configurationService.dequeueSetSpecialDaysResponse(request
                     .getCorrelationUid());
 
@@ -189,11 +200,10 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             if (meterResponseData.getMessageData() instanceof String) {
                 response.setDescription((String) meterResponseData.getMessageData());
             }
-
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "SetConfigurationObjectRequest", namespace = SMARTMETER_CONFIGURATION_NAMESPACE)
@@ -223,8 +233,9 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             @OrganisationIdentification final String organisationIdentification,
             @RequestPayload final SetConfigurationObjectAsyncRequest request) throws OsgpException {
 
+        SetConfigurationObjectResponse response = null;
         try {
-            final SetConfigurationObjectResponse response = new SetConfigurationObjectResponse();
+            response = new SetConfigurationObjectResponse();
             final MeterResponseData meterResponseData = this.configurationService
                     .dequeueSetConfigurationObjectResponse(request.getCorrelationUid());
 
@@ -232,11 +243,10 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             if (meterResponseData.getMessageData() instanceof String) {
                 response.setDescription((String) meterResponseData.getMessageData());
             }
-
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "SetActivityCalendarRequest", namespace = SMARTMETER_CONFIGURATION_NAMESPACE)
@@ -247,8 +257,9 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
 
         LOGGER.info("Incoming SetActivityCalendarRequest for meter: {}.", request.getDeviceIdentification());
 
+        SetActivityCalendarAsyncResponse response = null;
         try {
-            final SetActivityCalendarAsyncResponse response = new SetActivityCalendarAsyncResponse();
+            response = new SetActivityCalendarAsyncResponse();
             final String deviceIdentification = request.getDeviceIdentification();
             final ActivityCalendarDataType requestData = request.getActivityCalendarData();
 
@@ -260,14 +271,14 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
 
             response.setCorrelationUid(correlationUid);
             response.setDeviceIdentification(request.getDeviceIdentification());
-            return response;
         } catch (final Exception e) {
 
             LOGGER.error("Exception: {} while setting activity calendar on device: {} for organisation {}.",
                     new Object[] { e.getMessage(), request.getDeviceIdentification(), organisationIdentification }, e);
 
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "SetActivityCalendarAsyncRequest", namespace = SMARTMETER_CONFIGURATION_NAMESPACE)
@@ -278,8 +289,9 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
 
         LOGGER.info("Incoming retrieveSetActivityCalendarResponse for meter: {}", request.getDeviceIdentification());
 
+        SetActivityCalendarResponse response = null;
         try {
-            final SetActivityCalendarResponse response = new SetActivityCalendarResponse();
+            response = new SetActivityCalendarResponse();
             final MeterResponseData meterResponseData = this.configurationService
                     .dequeueSetActivityCalendarResponse(request.getCorrelationUid());
 
@@ -287,10 +299,10 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             if (meterResponseData.getMessageData() instanceof String) {
                 response.setDescription((String) meterResponseData.getMessageData());
             }
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "SetAlarmNotificationsRequest", namespace = SMARTMETER_CONFIGURATION_NAMESPACE)
@@ -301,8 +313,9 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
 
         LOGGER.info("Incoming SetAlarmNotificationsRequest for meter: {}.", request.getDeviceIdentification());
 
+        SetAlarmNotificationsAsyncResponse response = null;
         try {
-            final SetAlarmNotificationsAsyncResponse response = new SetAlarmNotificationsAsyncResponse();
+            response = new SetAlarmNotificationsAsyncResponse();
             final String deviceIdentification = request.getDeviceIdentification();
             final SetAlarmNotificationsRequestData requestData = request.getSetAlarmNotificationsRequestData();
 
@@ -316,15 +329,14 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             asyncResponse.setCorrelationUid(correlationUid);
             asyncResponse.setDeviceIdentification(request.getDeviceIdentification());
             response.setAsyncResponse(asyncResponse);
-
-            return response;
         } catch (final Exception e) {
 
             LOGGER.error("Exception: {} while setting alarm notifications on device: {} for organisation {}.",
                     new Object[] { e.getMessage(), request.getDeviceIdentification(), organisationIdentification }, e);
 
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "SetAlarmNotificationsAsyncRequest", namespace = SMARTMETER_CONFIGURATION_NAMESPACE)
@@ -333,8 +345,9 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             @OrganisationIdentification final String organisationIdentification,
             @RequestPayload final SetAlarmNotificationsAsyncRequest request) throws OsgpException {
 
+        SetAlarmNotificationsResponse response = null;
         try {
-            final SetAlarmNotificationsResponse response = new SetAlarmNotificationsResponse();
+            response = new SetAlarmNotificationsResponse();
             final MeterResponseData meterResponseData = this.configurationService
                     .dequeueSetConfigurationObjectResponse(request.getCorrelationUid());
 
@@ -342,10 +355,10 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             if (meterResponseData.getMessageData() instanceof String) {
                 response.setDescription((String) meterResponseData.getMessageData());
             }
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
 }

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringConfigurationEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringConfigurationEndpoint.java
@@ -52,9 +52,7 @@ import com.alliander.osgp.adapter.ws.smartmetering.application.services.Configur
 import com.alliander.osgp.adapter.ws.smartmetering.domain.entities.MeterResponseData;
 import com.alliander.osgp.domain.core.valueobjects.smartmetering.ActivityCalendar;
 import com.alliander.osgp.domain.core.valueobjects.smartmetering.AlarmNotifications;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 
 @Endpoint
 public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
@@ -85,7 +83,7 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
                 organisationIdentification, request.getDeviceIdentification(), dataRequest);
 
         final SetAdministrativeStatusAsyncResponse asyncResponse = new com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ObjectFactory()
-        .createSetAdministrativeStatusAsyncResponse();
+                .createSetAdministrativeStatusAsyncResponse();
         asyncResponse.setCorrelationUid(correlationUid);
         asyncResponse.setDeviceIdentification(request.getDeviceIdentification());
 
@@ -124,7 +122,7 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
                 organisationIdentification, request.getDeviceIdentification());
 
         final GetAdministrativeStatusAsyncResponse asyncResponse = new com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ObjectFactory()
-        .createGetAdministrativeStatusAsyncResponse();
+                .createGetAdministrativeStatusAsyncResponse();
 
         asyncResponse.setCorrelationUid(correlationUid);
         asyncResponse.setDeviceIdentification(request.getDeviceIdentification());
@@ -143,15 +141,7 @@ public class SmartMeteringConfigurationEndpoint extends SmartMeteringEndpoint {
             final MeterResponseData meterResponseData = this.configurationService
                     .dequeueGetAdministrativeStatusResponse(request.getCorrelationUid());
 
-            if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
-                if (meterResponseData.getMessageData() instanceof String) {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            (String) meterResponseData.getMessageData(), null);
-                } else {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            "An exception occurred retrieving the administrative status.", null);
-                }
-            }
+            this.throwExceptionIfResultNotOk(meterResponseData, "retrieving the administrative status");
 
             response = new GetAdministrativeStatusResponse();
             final AdministrativeStatusType dataRequest = this.configurationMapper.map(

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringEndpoint.java
@@ -20,17 +20,17 @@ abstract class SmartMeteringEndpoint {
      *            cause
      * @throws OsgpException
      */
-    protected OsgpException handleException(final Exception e) {
+    protected void handleException(final Exception e) throws OsgpException {
         if (e instanceof OsgpException) {
             if (e instanceof UnknownCorrelationUidException) {
                 LOGGER.warn(e.getMessage());
             } else {
                 LOGGER.error("Exception occurred: ", e);
             }
-            return (OsgpException) e;
+            throw (OsgpException) e;
         } else {
             LOGGER.error("Exception occurred: ", e);
-            return new TechnicalException(ComponentType.WS_SMART_METERING, e);
+            throw new TechnicalException(ComponentType.WS_SMART_METERING, e);
         }
     }
 }

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringEndpoint.java
@@ -3,6 +3,8 @@ package com.alliander.osgp.adapter.ws.smartmetering.endpoints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.alliander.osgp.adapter.ws.schema.smartmetering.common.OsgpResultType;
+import com.alliander.osgp.adapter.ws.smartmetering.domain.entities.MeterResponseData;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
 import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
@@ -31,6 +33,19 @@ abstract class SmartMeteringEndpoint {
         } else {
             LOGGER.error("Exception occurred: ", e);
             throw new TechnicalException(ComponentType.WS_SMART_METERING, e);
+        }
+    }
+
+    protected void throwExceptionIfResultNotOk(final MeterResponseData meterResponseData, final String exceptionContext)
+            throws OsgpException {
+        if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
+            if (meterResponseData.getMessageData() instanceof String) {
+                throw new TechnicalException(ComponentType.WS_SMART_METERING,
+                        (String) meterResponseData.getMessageData(), null);
+            } else {
+                throw new TechnicalException(ComponentType.WS_SMART_METERING, String.format(
+                        "An exception occurred %s.", exceptionContext), null);
+            }
         }
     }
 }

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringInstallationEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringInstallationEndpoint.java
@@ -59,8 +59,9 @@ public class SmartMeteringInstallationEndpoint extends SmartMeteringEndpoint {
 
         LOGGER.info("Incoming AddDeviceRequest for meter: {}.", request.getDevice().getDeviceIdentification());
 
+        AddDeviceAsyncResponse response = null;
         try {
-            final AddDeviceAsyncResponse response = new AddDeviceAsyncResponse();
+            response = new AddDeviceAsyncResponse();
             final SmartMeteringDevice device = this.installationMapper.map(request.getDevice(),
                     SmartMeteringDevice.class);
 
@@ -70,7 +71,6 @@ public class SmartMeteringInstallationEndpoint extends SmartMeteringEndpoint {
             response.setCorrelationUid(correlationUid);
             response.setDeviceIdentification(request.getDevice().getDeviceIdentification());
 
-            return response;
         } catch (final MethodConstraintViolationException e) {
 
             LOGGER.error("Exception: {} while adding device: {} for organisation {}.", new Object[] { e.getMessage(),
@@ -84,8 +84,9 @@ public class SmartMeteringInstallationEndpoint extends SmartMeteringEndpoint {
             LOGGER.error("Exception: {} while adding device: {} for organisation {}.", new Object[] { e.getMessage(),
                     request.getDevice().getDeviceIdentification(), organisationIdentification }, e);
 
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "AddDeviceAsyncRequest", namespace = SMARTMETER_INSTALLATION_NAMESPACE)
@@ -94,8 +95,9 @@ public class SmartMeteringInstallationEndpoint extends SmartMeteringEndpoint {
             @OrganisationIdentification final String organisationIdentification,
             @RequestPayload final AddDeviceAsyncRequest request) throws OsgpException {
 
+        AddDeviceResponse response = null;
         try {
-            final AddDeviceResponse response = new AddDeviceResponse();
+            response = new AddDeviceResponse();
             final MeterResponseData meterResponseData = this.installationService.dequeueAddSmartMeterResponse(request
                     .getCorrelationUid());
 
@@ -104,10 +106,10 @@ public class SmartMeteringInstallationEndpoint extends SmartMeteringEndpoint {
                 response.setDescription((String) meterResponseData.getMessageData());
             }
 
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
 }

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringManagementEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringManagementEndpoint.java
@@ -71,9 +71,10 @@ public class SmartMeteringManagementEndpoint extends SmartMeteringEndpoint {
         LOGGER.info("Find events request for organisation: {} and device: {}.", organisationIdentification,
                 request.getDeviceIdentification());
 
+        FindEventsAsyncResponse response = null;
         try {
             // Create response.
-            final FindEventsAsyncResponse response = new FindEventsAsyncResponse();
+            response = new FindEventsAsyncResponse();
 
             // Get the request parameters, make sure that date time are in UTC.
             final String deviceIdentification = request.getDeviceIdentification();
@@ -86,10 +87,10 @@ public class SmartMeteringManagementEndpoint extends SmartMeteringEndpoint {
             response.setCorrelationUid(correlationUid);
             response.setDeviceIdentification(request.getDeviceIdentification());
 
-            return response;
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "FindEventsAsyncRequest", namespace = NAMESPACE)
@@ -101,9 +102,10 @@ public class SmartMeteringManagementEndpoint extends SmartMeteringEndpoint {
         LOGGER.info("Get find events response for organisation: {} and device: {}.", organisationIdentification,
                 request.getDeviceIdentification());
 
+        FindEventsResponse response = null;
         try {
             // Create response.
-            final FindEventsResponse response = new FindEventsResponse();
+            response = new FindEventsResponse();
 
             // Get the request parameters, make sure that date time are in UTC.
             final String deviceIdentification = request.getDeviceIdentification();
@@ -121,14 +123,14 @@ public class SmartMeteringManagementEndpoint extends SmartMeteringEndpoint {
                     this.managementMapper.mapAsList(events,
                             com.alliander.osgp.adapter.ws.schema.smartmetering.management.Event.class));
             LOGGER.info("mapping done, sending response...");
-            return response;
         } catch (final MethodConstraintViolationException e) {
             LOGGER.error("FindEventsRequest Exception", e.getMessage(), e.getStackTrace(), e);
             throw new FunctionalException(FunctionalExceptionType.VALIDATION_ERROR, ComponentType.WS_SMART_METERING,
                     new ValidationException(e.getConstraintViolations()));
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
     @PayloadRoot(localPart = "GetDevicesRequest", namespace = NAMESPACE)
@@ -138,8 +140,9 @@ public class SmartMeteringManagementEndpoint extends SmartMeteringEndpoint {
 
         LOGGER.info("Get Devices Request received from organisation: {}.", organisationIdentification);
 
+        GetDevicesResponse response = null;
         try {
-            final GetDevicesResponse response = new GetDevicesResponse();
+            response = new GetDevicesResponse();
             final Page<Device> page = this.managementService.findAllDevices(organisationIdentification,
                     request.getPage());
 
@@ -149,14 +152,14 @@ public class SmartMeteringManagementEndpoint extends SmartMeteringEndpoint {
                     this.managementMapper.mapAsList(page.getContent(),
                             com.alliander.osgp.adapter.ws.schema.smartmetering.management.Device.class));
             response.setDevicePage(devicePage);
-            return response;
         } catch (final MethodConstraintViolationException e) {
             LOGGER.error("Exception: {}, StackTrace: {}", e.getMessage(), e.getStackTrace(), e);
             throw new FunctionalException(FunctionalExceptionType.VALIDATION_ERROR, COMPONENT_WS_SMART_METERING,
                     new ValidationException(e.getConstraintViolations()));
         } catch (final Exception e) {
-            throw this.handleException(e);
+            this.handleException(e);
         }
+        return response;
     }
 
 }

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringMonitoringEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringMonitoringEndpoint.java
@@ -18,7 +18,6 @@ import org.springframework.ws.server.endpoint.annotation.ResponsePayload;
 import com.alliander.osgp.adapter.ws.endpointinterceptors.OrganisationIdentification;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.common.AsyncRequest;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.common.AsyncResponse;
-import com.alliander.osgp.adapter.ws.schema.smartmetering.common.OsgpResultType;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.ActualMeterReadsAsyncRequest;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.ActualMeterReadsAsyncResponse;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.ActualMeterReadsGasAsyncRequest;
@@ -43,10 +42,8 @@ import com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.ReadAlarmRe
 import com.alliander.osgp.adapter.ws.smartmetering.application.mapping.MonitoringMapper;
 import com.alliander.osgp.adapter.ws.smartmetering.application.services.MonitoringService;
 import com.alliander.osgp.adapter.ws.smartmetering.domain.entities.MeterResponseData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.FunctionalException;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 
 @Endpoint
 public class SmartMeteringMonitoringEndpoint extends SmartMeteringEndpoint {
@@ -125,15 +122,7 @@ public class SmartMeteringMonitoringEndpoint extends SmartMeteringEndpoint {
             final MeterResponseData meterResponseData = this.monitoringService
                     .dequeuePeriodicMeterReadsResponse(request.getCorrelationUid());
 
-            if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
-                if (meterResponseData.getMessageData() instanceof String) {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            (String) meterResponseData.getMessageData(), null);
-                } else {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            "An exception occurred retrieving the periodic meter reads.", null);
-                }
-            }
+            this.throwExceptionIfResultNotOk(meterResponseData, "retrieving the periodic meter reads");
 
             response = this.monitoringMapper.map(meterResponseData.getMessageData(),
                     com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.PeriodicMeterReadsResponse.class);
@@ -156,15 +145,7 @@ public class SmartMeteringMonitoringEndpoint extends SmartMeteringEndpoint {
             final MeterResponseData meterResponseData = this.monitoringService
                     .dequeuePeriodicMeterReadsGasResponse(request.getCorrelationUid());
 
-            if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
-                if (meterResponseData.getMessageData() instanceof String) {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            (String) meterResponseData.getMessageData(), null);
-                } else {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            "An exception occurred retrieving the periodic meter reads for gas.", null);
-                }
-            }
+            this.throwExceptionIfResultNotOk(meterResponseData, "retrieving the periodic meter reads for gas");
 
             response = this.monitoringMapper.map(meterResponseData.getMessageData(),
                     com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.PeriodicMeterReadsGasResponse.class);
@@ -251,15 +232,7 @@ public class SmartMeteringMonitoringEndpoint extends SmartMeteringEndpoint {
             final MeterResponseData meterResponseData = this.monitoringService.dequeueActualMeterReadsResponse(request
                     .getCorrelationUid());
 
-            if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
-                if (meterResponseData.getMessageData() instanceof String) {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            (String) meterResponseData.getMessageData(), null);
-                } else {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            "An exception occurred retrieving the actual meter reads.", null);
-                }
-            }
+            this.throwExceptionIfResultNotOk(meterResponseData, "retrieving the actual meter reads");
 
             response = this.monitoringMapper.map(meterResponseData.getMessageData(), ActualMeterReadsResponse.class);
         } catch (final Exception e) {
@@ -281,15 +254,7 @@ public class SmartMeteringMonitoringEndpoint extends SmartMeteringEndpoint {
             final MeterResponseData meterResponseData = this.monitoringService
                     .dequeueActualMeterReadsGasResponse(request.getCorrelationUid());
 
-            if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
-                if (meterResponseData.getMessageData() instanceof String) {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            (String) meterResponseData.getMessageData(), null);
-                } else {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            "An exception occurred retrieving the actual meter reads for gas.", null);
-                }
-            }
+            this.throwExceptionIfResultNotOk(meterResponseData, "retrieving the actual meter reads for gas");
 
             response = this.monitoringMapper.map(meterResponseData.getMessageData(), ActualMeterReadsGasResponse.class);
         } catch (final Exception e) {
@@ -344,15 +309,7 @@ public class SmartMeteringMonitoringEndpoint extends SmartMeteringEndpoint {
             final MeterResponseData meterResponseData = this.monitoringService.dequeueReadAlarmRegisterResponse(request
                     .getCorrelationUid());
 
-            if (OsgpResultType.NOT_OK == OsgpResultType.fromValue(meterResponseData.getResultType().getValue())) {
-                if (meterResponseData.getMessageData() instanceof String) {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            (String) meterResponseData.getMessageData(), null);
-                } else {
-                    throw new TechnicalException(ComponentType.WS_SMART_METERING,
-                            "An exception occurred retrieving the alarm register.", null);
-                }
-            }
+            this.throwExceptionIfResultNotOk(meterResponseData, "retrieving the alarm register");
 
             response.setAlarmRegister(this.monitoringMapper.map(meterResponseData.getMessageData(),
                     com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.AlarmRegister.class));

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/infra/jms/messageprocessor/DomainResponseMessageProcessor.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/infra/jms/messageprocessor/DomainResponseMessageProcessor.java
@@ -82,7 +82,7 @@ public abstract class DomainResponseMessageProcessor implements MessageProcessor
 
     @Override
     public void processMessage(final ObjectMessage message) throws JMSException {
-        LOGGER.debug("Processing smart metering actual meter reads response message");
+        LOGGER.debug("Processing smart metering response message");
 
         String correlationUid = null;
         String messageType = null;

--- a/osgp-core/src/main/java/com/alliander/osgp/core/application/services/DeviceResponseMessageService.java
+++ b/osgp-core/src/main/java/com/alliander/osgp/core/application/services/DeviceResponseMessageService.java
@@ -56,7 +56,8 @@ public class DeviceResponseMessageService {
 
             // The array of exceptions which have to be retried.
             final String[] retryExceptions = { "Unable to connect", "ConnectException",
-                    "Failed to receive response within timelimit" };
+                    "Failed to receive response within timelimit", "Timeout waiting for",
+            "Connection closed by remote host while waiting for association response" };
             Boolean retryMessage = false;
 
             // Validate the actual exception with the list of exception to be

--- a/osgp-core/src/main/java/com/alliander/osgp/core/infra/jms/domain/DomainResponseMessageSender.java
+++ b/osgp-core/src/main/java/com/alliander/osgp/core/infra/jms/domain/DomainResponseMessageSender.java
@@ -78,12 +78,10 @@ public class DomainResponseMessageSender implements DomainResponseService {
     }
 
     private ResponseMessage createResponseMessage(final ProtocolResponseMessage protocolResponseMessage) {
-        final OsgpException osgpException = protocolResponseMessage.getOsgpException() == null ? null
-                : protocolResponseMessage.getOsgpException();
         return new ResponseMessage(protocolResponseMessage.getCorrelationUid(),
                 protocolResponseMessage.getOrganisationIdentification(),
-                protocolResponseMessage.getDeviceIdentification(), protocolResponseMessage.getResult(), osgpException,
-                protocolResponseMessage.getDataObject());
+                protocolResponseMessage.getDeviceIdentification(), protocolResponseMessage.getResult(),
+                protocolResponseMessage.getOsgpException(), protocolResponseMessage.getDataObject());
     }
 
     private ResponseMessage createResponseMessage(final ProtocolRequestMessage protocolRequestMessage, final Exception e) {


### PR DESCRIPTION
When the retry mechanism was fixed, it became necessary to send the
initial request data back with a response for failure, to allow
resending it.
This caused issues with response message processors that were not up for
this task, which have been taken care of as well.

Fixes OSGP/Platform#315