### PR TITLE
Reimplements hashCode() and equals() functions for domain entities. FLEX-1377

### DIFF
--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Device.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Device.java
@@ -12,6 +12,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -230,11 +231,7 @@ public class Device implements Serializable {
             return false;
         }
         final Device device = (Device) o;
-        if (this.deviceIdentification != null ? !this.deviceIdentification.equals(device.deviceIdentification)
-                : device.deviceIdentification != null) {
-            return false;
-        }
-        return true;
+        return Objects.equals(this.deviceIdentification, device.deviceIdentification);
     }
 
     public String getAlias() {
@@ -343,7 +340,7 @@ public class Device implements Serializable {
 
     @Override
     public int hashCode() {
-        return this.deviceIdentification != null ? this.deviceIdentification.hashCode() : 0;
+        return Objects.hashCode(this.deviceIdentification);
     }
 
     public boolean isActivated() {

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Device.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Device.java
@@ -230,22 +230,8 @@ public class Device implements Serializable {
             return false;
         }
         final Device device = (Device) o;
-        if (this.isActivated != device.isActivated) {
-            return false;
-        }
-        if (this.authorizations != null ? !this.authorizations.equals(device.authorizations)
-                : device.authorizations != null) {
-            return false;
-        }
         if (this.deviceIdentification != null ? !this.deviceIdentification.equals(device.deviceIdentification)
                 : device.deviceIdentification != null) {
-            return false;
-        }
-        if (this.deviceType != null ? !this.deviceType.equals(device.deviceType) : device.deviceType != null) {
-            return false;
-        }
-        if (this.networkAddress != null ? !this.networkAddress.equals(device.networkAddress)
-                : device.networkAddress != null) {
             return false;
         }
         return true;
@@ -357,12 +343,7 @@ public class Device implements Serializable {
 
     @Override
     public int hashCode() {
-        int result = this.deviceIdentification != null ? this.deviceIdentification.hashCode() : 0;
-        result = 31 * result + (this.deviceType != null ? this.deviceType.hashCode() : 0);
-        result = 31 * result + (this.networkAddress != null ? this.networkAddress.hashCode() : 0);
-        result = 31 * result + (this.isActivated ? 1 : 0);
-        result = 31 * result + (this.authorizations != null ? this.authorizations.hashCode() : 0);
-        return result;
+        return this.deviceIdentification != null ? this.deviceIdentification.hashCode() : 0;
     }
 
     public boolean isActivated() {
@@ -398,7 +379,7 @@ public class Device implements Serializable {
     /**
      * This setter is only needed for testing. Don't use this in production
      * code.
-     * 
+     *
      * @param id
      *            The id.
      */

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DeviceAuthorization.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DeviceAuthorization.java
@@ -85,6 +85,6 @@ public class DeviceAuthorization extends AbstractEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.device.getDeviceIdentification());
+        return Objects.hash(this.device, this.organisation, this.functionGroup.name());
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DeviceAuthorization.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DeviceAuthorization.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.domain.core.entities;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -71,30 +73,18 @@ public class DeviceAuthorization extends AbstractEntity {
         }
         final DeviceAuthorization authorization = (DeviceAuthorization) o;
         // Only comparing the device and organisation identifications (and not
-        // the complete objects) to prevent stack
-        // overflow errors when comparing devices (which contain device
-        // authorizations).
-        if (this.device != null ? !this.device.getDeviceIdentification().equals(
-                authorization.device.getDeviceIdentification()) : authorization.device != null) {
-            return false;
-        }
-        if (this.organisation != null ? !this.organisation.getOrganisationIdentification().equals(
-                authorization.organisation.getOrganisationIdentification()) : authorization.organisation != null) {
-            return false;
-        }
-        if (this.functionGroup != null ? !this.functionGroup.equals(authorization.functionGroup)
-                : authorization.functionGroup != null) {
-            return false;
-        }
-        return true;
+        // the complete objects) to prevent stack overflow errors when comparing
+        // devices (which contain device authorizations).
+        final boolean isDeviceEqual = Objects.equals(this.device, authorization.device);
+        final boolean isOrganisationEqual = Objects.equals(this.organisation, authorization.organisation);
+        final boolean isDeviceFunctionGroupEqual = Objects.equals(this.functionGroup.name(),
+                authorization.functionGroup.name());
+
+        return isDeviceEqual && isOrganisationEqual && isDeviceFunctionGroupEqual;
     }
 
     @Override
     public int hashCode() {
-        int result = this.device != null ? this.device.getDeviceIdentification().hashCode() : 0;
-        result = 31 * result
-                + (this.organisation != null ? this.organisation.getOrganisationIdentification().hashCode() : 0);
-        result = 31 * result + (this.functionGroup != null ? this.functionGroup.hashCode() : 0);
-        return result;
+        return Objects.hashCode(this.device.getDeviceIdentification());
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DeviceAuthorization.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DeviceAuthorization.java
@@ -77,8 +77,7 @@ public class DeviceAuthorization extends AbstractEntity {
         // devices (which contain device authorizations).
         final boolean isDeviceEqual = Objects.equals(this.device, authorization.device);
         final boolean isOrganisationEqual = Objects.equals(this.organisation, authorization.organisation);
-        final boolean isDeviceFunctionGroupEqual = Objects.equals(this.functionGroup.name(),
-                authorization.functionGroup.name());
+        final boolean isDeviceFunctionGroupEqual = Objects.equals(this.functionGroup, authorization.functionGroup);
 
         return isDeviceEqual && isOrganisationEqual && isDeviceFunctionGroupEqual;
     }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DomainInfo.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DomainInfo.java
@@ -132,4 +132,24 @@ public class DomainInfo extends AbstractEntity {
         return this.incomingDomainResponsesQueue;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DomainInfo)) {
+            return false;
+        }
+        final DomainInfo domainInfo = (DomainInfo) o;
+        if (!domainInfo.getKey().equals(this.getKey())) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getKey() != null ? this.getKey().hashCode() : 0;
+    }
+
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DomainInfo.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DomainInfo.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.domain.core.entities;
 
+import java.util.Objects;
+
 import javax.persistence.Entity;
 
 import com.alliander.osgp.shared.domain.entities.AbstractEntity;
@@ -141,15 +143,11 @@ public class DomainInfo extends AbstractEntity {
             return false;
         }
         final DomainInfo domainInfo = (DomainInfo) o;
-        if (!domainInfo.getKey().equals(this.getKey())) {
-            return false;
-        }
-        return true;
+        return Objects.equals(this.getKey(), domainInfo.getKey());
     }
 
     @Override
     public int hashCode() {
-        return this.getKey() != null ? this.getKey().hashCode() : 0;
+        return Objects.hash(this.getKey());
     }
-
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DomainInfo.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/DomainInfo.java
@@ -148,6 +148,6 @@ public class DomainInfo extends AbstractEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.getKey());
+        return Objects.hashCode(this.getKey());
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Ean.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Ean.java
@@ -33,14 +33,8 @@ public class Ean extends AbstractEntity {
         // Default constructor
     }
 
-    /**
-     * Constructor.
-     *
-     * @param device
-     * @param code
-     * @param description
-     */
     public Ean(final Device device, final String code, final String description) {
+        this.device = device;
         this.code = code;
         this.description = description;
     }
@@ -62,7 +56,7 @@ public class Ean extends AbstractEntity {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof Event)) {
+        if (!(o instanceof Ean)) {
             return false;
         }
         final Ean other = (Ean) o;

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Ean.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Ean.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.domain.core.entities;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -60,24 +62,15 @@ public class Ean extends AbstractEntity {
             return false;
         }
         final Ean other = (Ean) o;
-        if (this.device != null ? !this.device.getDeviceIdentification().equals(other.device.getDeviceIdentification())
-                : other.device != null) {
-            return false;
-        }
-        if (this.code != null ? !this.code.equals(other.code) : other.code != null) {
-            return false;
-        }
-        if (this.description != null ? !this.description.equals(other.description) : other.description != null) {
-            return false;
-        }
-        return true;
+        final boolean isDeviceEqual = Objects.equals(this.device, other.device);
+        final boolean isCodeEqual = Objects.equals(this.code, other.code);
+        final boolean isDescriptionEqual = Objects.equals(this.description, other.description);
+
+        return isDeviceEqual && isCodeEqual && isDescriptionEqual;
     }
 
     @Override
     public int hashCode() {
-        int result = this.code != null ? this.code.hashCode() : 0;
-        result = 31 * result + (this.description != null ? this.description.hashCode() : 0);
-        result = 31 * result + (this.device != null ? this.device.hashCode() : 0);
-        return result;
+        return Objects.hash(this.device, this.code, this.description);
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Event.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Event.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.domain.core.entities;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -72,27 +74,16 @@ public class Event extends AbstractEntity {
             return false;
         }
         final Event other = (Event) o;
-        if (this.device != null ? !this.device.equals(other.device) : other.device != null) {
-            return false;
-        }
-        if (this.eventType != null ? !this.eventType.equals(other.eventType) : other.eventType != null) {
-            return false;
-        }
-        if (this.description != null ? !this.description.equals(other.description) : other.description != null) {
-            return false;
-        }
-        if (this.index != null ? !this.index.equals(other.index) : other.index != null) {
-            return false;
-        }
-        return true;
+        final boolean isDeviceEqual = Objects.equals(this.device, other.device);
+        final boolean isEventTypeEqual = Objects.equals(this.eventType, other.eventType);
+        final boolean isDescriptionEqual = Objects.equals(this.description, other.description);
+        final boolean isIndexEqual = Objects.equals(this.index, other.index);
+
+        return isDeviceEqual && isEventTypeEqual && isDescriptionEqual && isIndexEqual;
     }
 
     @Override
     public int hashCode() {
-        int result = this.device != null ? this.device.hashCode() : 0;
-        result = 31 * result + (this.eventType != null ? this.eventType.hashCode() : 0);
-        result = 31 * result + (this.description != null ? this.description.hashCode() : 0);
-        result = 31 * result + (this.index != null ? this.index.hashCode() : 0);
-        return result;
+        return Objects.hash(this.device, this.eventType, this.description, this.index);
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Event.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Event.java
@@ -40,14 +40,6 @@ public class Event extends AbstractEntity {
         // Default constructor
     }
 
-    /**
-     * Constructor.
-     *
-     * @param device
-     * @param eventType
-     * @param description
-     * @param index
-     */
     public Event(final Device device, final EventType eventType, final String description, final Integer index) {
         this.device = device;
         this.eventType = eventType;

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Organisation.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Organisation.java
@@ -9,6 +9,7 @@ package com.alliander.osgp.domain.core.entities;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -118,12 +119,7 @@ public class Organisation extends AbstractEntity {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
-        result = prime * result
-                + ((this.organisationIdentification == null) ? 0 : this.organisationIdentification.hashCode());
-        return result;
+        return Objects.hashCode(this.organisationIdentification);
     }
 
     @Override
@@ -138,21 +134,8 @@ public class Organisation extends AbstractEntity {
             return false;
         }
         final Organisation other = (Organisation) o;
-        if (this.name == null) {
-            if (other.name != null) {
-                return false;
-            }
-        } else if (!this.name.equals(other.name)) {
-            return false;
-        }
-        if (this.organisationIdentification == null) {
-            if (other.organisationIdentification != null) {
-                return false;
-            }
-        } else if (!this.organisationIdentification.equals(other.organisationIdentification)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(this.organisationIdentification, other.organisationIdentification);
+
     }
 
     public PlatformFunctionGroup getFunctionGroup() {

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Organisation.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Organisation.java
@@ -120,7 +120,6 @@ public class Organisation extends AbstractEntity {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((this.authorizations == null) ? 0 : this.authorizations.hashCode());
         result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
         result = prime * result
                 + ((this.organisationIdentification == null) ? 0 : this.organisationIdentification.hashCode());
@@ -128,24 +127,17 @@ public class Organisation extends AbstractEntity {
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj == null) {
+        if (o == null) {
             return false;
         }
-        if (this.getClass() != obj.getClass()) {
+        if (!(o instanceof Organisation)) {
             return false;
         }
-        final Organisation other = (Organisation) obj;
-        if (this.authorizations == null) {
-            if (other.authorizations != null) {
-                return false;
-            }
-        } else if (!this.authorizations.equals(other.authorizations)) {
-            return false;
-        }
+        final Organisation other = (Organisation) o;
         if (this.name == null) {
             if (other.name != null) {
                 return false;
@@ -153,30 +145,11 @@ public class Organisation extends AbstractEntity {
         } else if (!this.name.equals(other.name)) {
             return false;
         }
-        if (this.prefix == null) {
-            if (other.prefix != null) {
-                return false;
-            }
-        } else if (!this.prefix.equals(other.prefix)) {
-            return false;
-        }
         if (this.organisationIdentification == null) {
             if (other.organisationIdentification != null) {
                 return false;
             }
         } else if (!this.organisationIdentification.equals(other.organisationIdentification)) {
-            return false;
-        }
-        if (this.functionGroup == null) {
-            return false;
-        } else if (!this.functionGroup.equals(other.functionGroup)) {
-            return false;
-        }
-        if (this.domains == null) {
-            if (other.domains != null) {
-                return false;
-            }
-        } else if (!this.domains.equals(other.domains)) {
             return false;
         }
         return true;

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Organisation.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Organisation.java
@@ -127,9 +127,6 @@ public class Organisation extends AbstractEntity {
         if (this == o) {
             return true;
         }
-        if (o == null) {
-            return false;
-        }
         if (!(o instanceof Organisation)) {
             return false;
         }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ProtocolInfo.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ProtocolInfo.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.domain.core.entities;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
@@ -74,20 +76,15 @@ public class ProtocolInfo extends AbstractEntity {
             return false;
         }
         final ProtocolInfo protocolInfo = (ProtocolInfo) o;
-        if (!protocolInfo.getProtocol().equals(this.protocol)) {
-            return false;
-        }
-        if (!protocolInfo.getProtocolVersion().equals(this.protocolVersion)) {
-            return false;
-        }
-        return true;
+        final boolean isProtocolEqual = Objects.equals(this.protocol, protocolInfo.protocol);
+        final boolean isProtocolVersionEqual = Objects.equals(this.protocolVersion, protocolInfo.protocolVersion);
+
+        return isProtocolEqual && isProtocolVersionEqual;
     }
 
     @Override
     public int hashCode() {
-        int result = this.protocol != null ? this.protocol.hashCode() : 0;
-        result = 31 * result + (this.protocolVersion != null ? this.protocolVersion.hashCode() : 0);
-        return result;
+        return Objects.hash(this.protocol, this.protocolVersion);
     }
 
     public String getProtocol() {

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ProtocolInfo.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ProtocolInfo.java
@@ -70,7 +70,7 @@ public class ProtocolInfo extends AbstractEntity {
         if (this == o) {
             return true;
         }
-        if (o == null || this.getClass() != o.getClass()) {
+        if (!(o instanceof ProtocolInfo)) {
             return false;
         }
         final ProtocolInfo protocolInfo = (ProtocolInfo) o;
@@ -80,18 +80,6 @@ public class ProtocolInfo extends AbstractEntity {
         if (!protocolInfo.getProtocolVersion().equals(this.protocolVersion)) {
             return false;
         }
-        if (!protocolInfo.getOutgoingProtocolRequestsQueue().equals(this.outgoingProtocolRequestsQueue)) {
-            return false;
-        }
-        if (!protocolInfo.getIncomingProtocolResponsesQueue().equals(this.incomingProtocolResponsesQueue)) {
-            return false;
-        }
-        if (!protocolInfo.getIncomingProtocolRequestsQueue().equals(this.incomingProtocolRequestsQueue)) {
-            return false;
-        }
-        if (!protocolInfo.getOutgoingProtocolResponsesQueue().equals(this.outgoingProtocolResponsesQueue)) {
-            return false;
-        }
         return true;
     }
 
@@ -99,14 +87,6 @@ public class ProtocolInfo extends AbstractEntity {
     public int hashCode() {
         int result = this.protocol != null ? this.protocol.hashCode() : 0;
         result = 31 * result + (this.protocolVersion != null ? this.protocolVersion.hashCode() : 0);
-        result = 31 * result
-                + (this.outgoingProtocolRequestsQueue != null ? this.outgoingProtocolRequestsQueue.hashCode() : 0);
-        result = 31 * result
-                + (this.incomingProtocolResponsesQueue != null ? this.incomingProtocolResponsesQueue.hashCode() : 0);
-        result = 31 * result
-                + (this.incomingProtocolRequestsQueue != null ? this.incomingProtocolRequestsQueue.hashCode() : 0);
-        result = 31 * result
-                + (this.outgoingProtocolResponsesQueue != null ? this.outgoingProtocolResponsesQueue.hashCode() : 0);
         return result;
     }
 
@@ -133,5 +113,4 @@ public class ProtocolInfo extends AbstractEntity {
     public String getOutgoingProtocolResponsesQueue() {
         return this.outgoingProtocolResponsesQueue;
     }
-
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/RelayStatus.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/RelayStatus.java
@@ -8,6 +8,7 @@
 package com.alliander.osgp.domain.core.entities;
 
 import java.util.Date;
+import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -96,19 +97,14 @@ public class RelayStatus extends AbstractEntity {
             return false;
         }
         final RelayStatus relayStatus = (RelayStatus) o;
-        if (!relayStatus.getDevice().getDeviceIdentification().equals(this.getDevice().getDeviceIdentification())) {
-            return false;
-        }
-        if (relayStatus.getIndex() != this.index) {
-            return false;
-        }
-        return true;
+        final boolean isDeviceEqual = Objects.equals(this.device, relayStatus.device);
+        final boolean isIndexEqual = Objects.equals(this.index, relayStatus.index);
+
+        return isDeviceEqual && isIndexEqual;
     }
 
     @Override
     public int hashCode() {
-        int result = this.getDevice().getDeviceIdentification().hashCode();
-        result = 31 * result + this.index;
-        return result;
+        return Objects.hash(this.device, this.index);
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/RelayStatus.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/RelayStatus.java
@@ -86,4 +86,29 @@ public class RelayStatus extends AbstractEntity {
     public void setIndex(final int index) {
         this.index = index;
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RelayStatus)) {
+            return false;
+        }
+        final RelayStatus relayStatus = (RelayStatus) o;
+        if (!relayStatus.getDevice().getDeviceIdentification().equals(this.getDevice().getDeviceIdentification())) {
+            return false;
+        }
+        if (relayStatus.getIndex() != this.index) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.getDevice().getDeviceIdentification().hashCode();
+        result = 31 * result + this.index;
+        return result;
+    }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ScheduledTask.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ScheduledTask.java
@@ -129,4 +129,24 @@ public class ScheduledTask extends AbstractEntity {
     public void setComplete() {
         this.status = ScheduledTaskStatusType.COMPLETE;
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ScheduledTask)) {
+            return false;
+        }
+        final ScheduledTask scheduledTask = (ScheduledTask) o;
+        if (!scheduledTask.getCorrelationId().equals(this.correlationUid)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getCorrelationId().hashCode();
+    }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ScheduledTask.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/ScheduledTask.java
@@ -9,6 +9,7 @@ package com.alliander.osgp.domain.core.entities;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -139,14 +140,11 @@ public class ScheduledTask extends AbstractEntity {
             return false;
         }
         final ScheduledTask scheduledTask = (ScheduledTask) o;
-        if (!scheduledTask.getCorrelationId().equals(this.correlationUid)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(this.correlationUid, scheduledTask.correlationUid);
     }
 
     @Override
     public int hashCode() {
-        return this.getCorrelationId().hashCode();
+        return Objects.hashCode(this.correlationUid);
     }
 }


### PR DESCRIPTION
- domain entities should only use business key values, not collections or object identifiers to calculate a hash
- see: https://developer.jboss.org/wiki/EqualsAndHashCode?_sscc=t