### PR TITLE
SLIM-532_Remove_unused_methods_from_enums

### DIFF
--- a/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/AdministrativeStatusTypeMappingTest.java
+++ b/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/AdministrativeStatusTypeMappingTest.java
@@ -35,7 +35,7 @@ public class AdministrativeStatusTypeMappingTest {
 
         // check if value is mapped correctly
         assertNotNull(administrativeStatusTypeDto);
-        assertEquals(administrativeStatusType.value(), administrativeStatusTypeDto.value());
+        assertEquals(administrativeStatusType.name(), administrativeStatusTypeDto.name());
     }
 
     // To see if mapping succeeds when a value is set to On.
@@ -51,7 +51,7 @@ public class AdministrativeStatusTypeMappingTest {
 
         // check if value is mapped correctly
         assertNotNull(administrativeStatusTypeDto);
-        assertEquals(administrativeStatusType.value(), administrativeStatusTypeDto.value());
+        assertEquals(administrativeStatusType.name(), administrativeStatusTypeDto.name());
     }
 
     // To see if mapping succeeds when a value is set to Off.
@@ -67,7 +67,7 @@ public class AdministrativeStatusTypeMappingTest {
 
         // check if value is mapped correctly
         assertNotNull(administrativeStatusTypeDto);
-        assertEquals(administrativeStatusType.value(), administrativeStatusTypeDto.value());
+        assertEquals(administrativeStatusType.name(), administrativeStatusTypeDto.name());
     }
 
     // check if mapping succeeds if the object is null.

--- a/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PeriodicMeterReadContainerMappingTest.java
+++ b/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PeriodicMeterReadContainerMappingTest.java
@@ -64,8 +64,8 @@ public class PeriodicMeterReadContainerMappingTest {
         assertNotNull(periodicMeterReadContainer);
 
         assertTrue(periodicMeterReadContainer.getPeriodicMeterReads().isEmpty());
-        assertEquals(periodicMeterReadsContainerDto.getPeriodType().value(), periodicMeterReadContainer.getPeriodType()
-                .value());
+        assertEquals(periodicMeterReadsContainerDto.getPeriodType().name(), periodicMeterReadContainer.getPeriodType()
+                .name());
     }
 
     // Test if mapping with a non-empty List succeeds
@@ -94,8 +94,8 @@ public class PeriodicMeterReadContainerMappingTest {
         // test mapping
         assertNotNull(periodicMeterReadsContainer);
 
-        assertEquals(periodicMeterReadsContainerDto.getPeriodType().value(), periodicMeterReadsContainer
-                .getPeriodType().value());
+        assertEquals(periodicMeterReadsContainerDto.getPeriodType().name(), periodicMeterReadsContainer.getPeriodType()
+                .name());
 
         assertEquals(periodicMeterReadsContainerDto.getPeriodicMeterReads().size(), periodicMeterReadsContainer
                 .getPeriodicMeterReads().size());

--- a/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PeriodicMeterReadsContainerGasMappingTest.java
+++ b/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PeriodicMeterReadsContainerGasMappingTest.java
@@ -64,8 +64,8 @@ public class PeriodicMeterReadsContainerGasMappingTest {
         assertNotNull(periodicMeterReadContainerGas);
 
         assertTrue(periodicMeterReadContainerGas.getMeterReadsGas().isEmpty());
-        assertEquals(periodicMeterReadsContainerGasDto.getPeriodType().value(), periodicMeterReadContainerGas
-                .getPeriodType().value());
+        assertEquals(periodicMeterReadsContainerGasDto.getPeriodType().name(), periodicMeterReadContainerGas
+                .getPeriodType().name());
     }
 
     // Test if mapping with a non-empty List succeeds
@@ -93,8 +93,8 @@ public class PeriodicMeterReadsContainerGasMappingTest {
         // test mapping
         assertNotNull(periodicMeterReadsContainerGas);
 
-        assertEquals(periodicMeterReadsContainerDto.getPeriodType().value(), periodicMeterReadsContainerGas
-                .getPeriodType().value());
+        assertEquals(periodicMeterReadsContainerDto.getPeriodType().name(), periodicMeterReadsContainerGas
+                .getPeriodType().name());
 
         assertEquals(periodicMeterReadsContainerDto.getMeterReadsGas().size(), periodicMeterReadsContainerGas
                 .getMeterReadsGas().size());

--- a/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PeriodicMeterReadsQueryMappingTest.java
+++ b/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PeriodicMeterReadsQueryMappingTest.java
@@ -65,8 +65,7 @@ public class PeriodicMeterReadsQueryMappingTest {
                 periodicMeterReadsQuery, PeriodicMeterReadsQueryDto.class);
         // test mapping
         assertNotNull(periodicMeterReadsQueryDto);
-        assertEquals(periodicMeterReadsQuery.getPeriodType().value(), periodicMeterReadsQueryDto.getPeriodType()
-                .value());
+        assertEquals(periodicMeterReadsQuery.getPeriodType().name(), periodicMeterReadsQueryDto.getPeriodType().name());
         assertEquals(periodicMeterReadsQuery.getBeginDate(), periodicMeterReadsQueryDto.getBeginDate());
         assertEquals(periodicMeterReadsQuery.getEndDate(), periodicMeterReadsQueryDto.getEndDate());
         assertEquals(periodicMeterReadsQuery.isMbusDevice(), periodicMeterReadsQueryDto.isMbusQuery());

--- a/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PushSetupAlarmMappingTest.java
+++ b/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PushSetupAlarmMappingTest.java
@@ -157,9 +157,9 @@ public class PushSetupAlarmMappingTest {
         assertNotNull(sendDestinationAndMethodDto);
 
         // make sure all instance variables are equal
-        assertEquals(sendDestinationAndMethod.getTransportService().value(), sendDestinationAndMethodDto
-                .getTransportService().value());
-        assertEquals(sendDestinationAndMethod.getMessage().value(), sendDestinationAndMethodDto.getMessage().value());
+        assertEquals(sendDestinationAndMethod.getTransportService().name(), sendDestinationAndMethodDto
+                .getTransportService().name());
+        assertEquals(sendDestinationAndMethod.getMessage().name(), sendDestinationAndMethodDto.getMessage().name());
         assertEquals(sendDestinationAndMethod.getDestination(), sendDestinationAndMethodDto.getDestination());
     }
 

--- a/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PushSetupSmsMappingTest.java
+++ b/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/PushSetupSmsMappingTest.java
@@ -156,9 +156,9 @@ public class PushSetupSmsMappingTest {
         assertNotNull(sendDestinationAndMethodDto);
 
         // make sure all instance variables are equal
-        assertEquals(sendDestinationAndMethod.getTransportService().value(), sendDestinationAndMethodDto
-                .getTransportService().value());
-        assertEquals(sendDestinationAndMethod.getMessage().value(), sendDestinationAndMethodDto.getMessage().value());
+        assertEquals(sendDestinationAndMethod.getTransportService().name(), sendDestinationAndMethodDto
+                .getTransportService().name());
+        assertEquals(sendDestinationAndMethod.getMessage().name(), sendDestinationAndMethodDto.getMessage().name());
         assertEquals(sendDestinationAndMethod.getDestination(), sendDestinationAndMethodDto.getDestination());
     }
 

--- a/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/SetConfigurationObjectRequestMappingTest.java
+++ b/osgp-adapter-domain-smartmetering/src/test/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/SetConfigurationObjectRequestMappingTest.java
@@ -165,7 +165,7 @@ public class SetConfigurationObjectRequestMappingTest {
 
         // check the GprsOperationModeTypeDto value
         final GprsOperationModeTypeDto gprsOperationModeTypeDto = configurationObjectDto.getGprsOperationMode();
-        assertEquals(gprsOperationModeType.value(), gprsOperationModeTypeDto.value());
+        assertEquals(gprsOperationModeType.name(), gprsOperationModeTypeDto.name());
 
         // check if ConfigurationFlagsDto object is present, and if its List is
         // of an equal size.
@@ -177,7 +177,7 @@ public class SetConfigurationObjectRequestMappingTest {
         // check ConfigurationObjectFlagTypeDto value.
         final ConfigurationFlagDto configurationFlagDto = configurationFlagsDto.getConfigurationFlag().get(0);
         final ConfigurationFlagTypeDto configurationFlagTypeDto = configurationFlagDto.getConfigurationFlagType();
-        assertEquals(configurationFlagType.value(), configurationFlagTypeDto.value());
+        assertEquals(configurationFlagType.name(), configurationFlagTypeDto.name());
     }
 
 }

--- a/osgp-adapter-ws-smartmetering/src/test/java/com/alliander/osgp/adapter/ws/smartmetering/application/mapping/AdministrativeStatusTypeMappingTest.java
+++ b/osgp-adapter-ws-smartmetering/src/test/java/com/alliander/osgp/adapter/ws/smartmetering/application/mapping/AdministrativeStatusTypeMappingTest.java
@@ -42,9 +42,9 @@ public class AdministrativeStatusTypeMappingTest {
         assertNotNull(off);
         assertNotNull(on);
 
-        assertEquals(AdministrativeStatusType.UNDEFINED.value(), undefined.value());
-        assertEquals(AdministrativeStatusType.OFF.value(), off.value());
-        assertEquals(AdministrativeStatusType.ON.value(), on.value());
+        assertEquals(AdministrativeStatusType.UNDEFINED.name(), undefined.name());
+        assertEquals(AdministrativeStatusType.OFF.name(), off.name());
+        assertEquals(AdministrativeStatusType.ON.name(), on.name());
     }
 
     /**
@@ -72,13 +72,13 @@ public class AdministrativeStatusTypeMappingTest {
 
         assertEquals(
                 com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.AdministrativeStatusType.UNDEFINED
-                .value(),
-                undefined.value());
+                .name(),
+                undefined.name());
         assertEquals(
-                com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.AdministrativeStatusType.OFF.value(),
-                off.value());
+                com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.AdministrativeStatusType.OFF.name(),
+                off.name());
         assertEquals(
-                com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.AdministrativeStatusType.ON.value(),
-                on.value());
+                com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.AdministrativeStatusType.ON.name(),
+                on.name());
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/AdministrativeStatusType.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/AdministrativeStatusType.java
@@ -7,18 +7,8 @@
  */
 package com.alliander.osgp.domain.core.valueobjects.smartmetering;
 
-
 public enum AdministrativeStatusType {
     UNDEFINED,
     OFF,
     ON;
-
-    public String value() {
-        return this.name();
-    }
-
-    public static AdministrativeStatusType fromValue(final String v) {
-        return valueOf(v);
-    }
-
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/AlarmType.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/AlarmType.java
@@ -31,12 +31,4 @@ public enum AlarmType {
     NEW_M_BUS_DEVICE_DISCOVERED_CHANNEL_3,
     NEW_M_BUS_DEVICE_DISCOVERED_CHANNEL_4;
 
-    public String value() {
-        return this.name();
-    }
-
-    public static AlarmType fromValue(final String v) {
-        return valueOf(v);
-    }
-
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/AmrProfileStatusCodeFlag.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/AmrProfileStatusCodeFlag.java
@@ -16,11 +16,4 @@ public enum AmrProfileStatusCodeFlag {
     CLOCK_ADJUSTED,
     POWER_DOWN;
 
-    public String value() {
-        return this.name();
-    }
-
-    public static AmrProfileStatusCodeFlag fromValue(final String v) {
-        return valueOf(v);
-    }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ClockStatusBit.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ClockStatusBit.java
@@ -31,10 +31,6 @@ public enum ClockStatusBit {
         return this.description;
     }
 
-    public String value() {
-        return this.name();
-    }
-
     public boolean isSet(final int clockStatus) {
         final int mask = 1 << this.ordinal();
         return mask == (mask & clockStatus);
@@ -74,10 +70,6 @@ public enum ClockStatusBit {
             status |= (1 << statusBit.ordinal());
         }
         return status;
-    }
-
-    public static ClockStatusBit fromValue(final String v) {
-        return valueOf(v);
     }
 
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ConfigurationFlagType.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ConfigurationFlagType.java
@@ -22,12 +22,4 @@ public enum ConfigurationFlagType {
     HLS_4_ON_PO_ENABLE,
     HLS_5_ON_PO_ENABLE;
 
-    public String value() {
-        return this.name();
-    }
-
-    public static ConfigurationFlagType fromValue(final String v) {
-        return valueOf(v);
-    }
-
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/GprsOperationModeType.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/GprsOperationModeType.java
@@ -14,11 +14,4 @@ public enum GprsOperationModeType {
     ALWAYS_ON,
     TRIGGERED;
 
-    public String value() {
-        return name();
-    }
-
-    public static GprsOperationModeType fromValue(String v) {
-        return valueOf(v);
-    }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/MessageType.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/MessageType.java
@@ -13,11 +13,4 @@ public enum MessageType {
     XML_ENCODED_X_DLMS_APDU,
     MANUFACTURER_SPECIFIC;
 
-    public String value() {
-        return this.name();
-    }
-
-    public static MessageType fromValue(final String v) {
-        return valueOf(v);
-    }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/PeriodType.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/PeriodType.java
@@ -13,12 +13,4 @@ public enum PeriodType {
     MONTHLY,
     INTERVAL;
 
-    public String value() {
-        return this.name();
-    }
-
-    public static PeriodType fromValue(final String v) {
-        return valueOf(v);
-    }
-
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/TransportServiceType.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/TransportServiceType.java
@@ -19,11 +19,4 @@ public enum TransportServiceType {
     ZIG_BEE,
     MANUFACTURER_SPECIFIC;
 
-    public String value() {
-        return this.name();
-    }
-
-    public static TransportServiceType fromValue(final String v) {
-        return valueOf(v);
-    }
 }


### PR DESCRIPTION
Changes some tests to call name() method directly instead of useless
value() method