### PR TITLE
SLIM-646 Handle bundle exception through separate action responses.

### DIFF
--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/OsgpCoreResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/OsgpCoreResponseMessageProcessor.java
@@ -125,7 +125,7 @@ public abstract class OsgpCoreResponseMessageProcessor implements MessageProcess
         try {
 
             if (osgpException != null) {
-                this.handleError(osgpException, deviceMessageMetadata);
+                this.handleError(osgpException, deviceMessageMetadata, responseMessage);
             } else if (this.hasRegularResponseObject(responseMessage)) {
                 LOGGER.info("Calling application service function to handle response: {}",
                         deviceMessageMetadata.getMessageType());
@@ -172,17 +172,36 @@ public abstract class OsgpCoreResponseMessageProcessor implements MessageProcess
     /**
      * In case of an error, this function can be used to send a response
      * containing the exception to the web-service-adapter.
+     * <p>
+     * The response message is provided to allow manipulation of certain
+     * responses, for instance in case the error has to be incorporated in the
+     * response instead of defining the response at its own.
      *
      * @param e
-     *            The exception.
-     * @param correlationUid
-     *            The correlation UID.
-     * @param organisationIdentification
-     *            The organisation identification.
-     * @param deviceIdentification
-     *            The device identification.
-     * @param messageType
-     *            The message type.
+     *            the exception.
+     * @param deviceMessageMetadata
+     *            the device message metadata.
+     * @param responseMessage
+     *            the response message.
+     * @throws FunctionalException
+     */
+    protected void handleError(final Exception e, final DeviceMessageMetadata deviceMessageMetadata,
+            final ResponseMessage responseMessage) throws FunctionalException {
+        if (responseMessage != null) {
+            LOGGER.debug("Handling error without using responseMessage for correlationUid: {}",
+                    responseMessage.getCorrelationUid());
+        }
+        this.handleError(e, deviceMessageMetadata);
+    }
+
+    /**
+     * In case of an error, this function can be used to send a response
+     * containing the exception to the web-service-adapter.
+     *
+     * @param e
+     *            the exception.
+     * @param deviceMessageMetadata
+     *            the device message metadata.
      */
     protected void handleError(final Exception e, final DeviceMessageMetadata deviceMessageMetadata) {
         LOGGER.info("handeling error: {} for message type: {}", e.getMessage(), deviceMessageMetadata.getMessageType());
@@ -193,7 +212,7 @@ public abstract class OsgpCoreResponseMessageProcessor implements MessageProcess
                 deviceMessageMetadata.getMessageType());
     }
 
-    private OsgpException ensureOsgpException(final Exception e) {
+    protected OsgpException ensureOsgpException(final Exception e) {
 
         if (e instanceof OsgpException) {
             return (OsgpException) e;

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/BundleResponseMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/core/messageprocessors/BundleResponseMessageProcessor.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.messageprocessors;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -14,6 +16,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.domain.smartmetering.application.services.BundleService;
 import com.alliander.osgp.adapter.domain.smartmetering.infra.jms.core.OsgpCoreResponseMessageProcessor;
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
+import com.alliander.osgp.dto.valueobjects.smartmetering.ActionDto;
+import com.alliander.osgp.dto.valueobjects.smartmetering.ActionResponseDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.BundleMessagesRequestDto;
 import com.alliander.osgp.shared.exceptionhandling.FunctionalException;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
@@ -42,6 +46,26 @@ public class BundleResponseMessageProcessor extends OsgpCoreResponseMessageProce
 
         final BundleMessagesRequestDto bundleMessagesResponseDto = (BundleMessagesRequestDto) responseMessage
                 .getDataObject();
+
+        this.bundleService.handleBundleResponse(deviceMessageMetadata, responseMessage.getResult(), osgpException,
+                bundleMessagesResponseDto);
+    }
+
+    @Override
+    protected void handleError(final Exception e, final DeviceMessageMetadata deviceMessageMetadata,
+            final ResponseMessage responseMessage) throws FunctionalException {
+
+        final OsgpException osgpException = this.ensureOsgpException(e);
+
+        final BundleMessagesRequestDto bundleMessagesResponseDto = (BundleMessagesRequestDto) responseMessage
+                .getDataObject();
+
+        final List<ActionDto> actionList = bundleMessagesResponseDto.getActionList();
+        for (final ActionDto action : actionList) {
+            if (action.getResponse() == null) {
+                action.setResponse(new ActionResponseDto(osgpException, "Unable to handle request"));
+            }
+        }
 
         this.bundleService.handleBundleResponse(deviceMessageMetadata, responseMessage.getResult(), osgpException,
                 bundleMessagesResponseDto);


### PR DESCRIPTION
If a retryable exception occurs handling a bundle of actions, and the
maximum number of retries has been reached, the exception is propagated
through the platform.
These changes preserve any separate action responses before the
exception occurred, and place the exception as response for all actions
that did not yet have a response.