### PR TITLE
SLIM-900 Implement selective access for Load Profile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = SLIM-900-Implement-selective-access-for-LoadProfiles
+	branch = development
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-900-Implement-selective-access-for-LoadProfiles
 

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MonitoringService.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MonitoringService.java
@@ -33,7 +33,6 @@ import com.alliander.osgp.dto.valueobjects.smartmetering.AlarmRegisterResponseDt
 import com.alliander.osgp.dto.valueobjects.smartmetering.ChannelDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.MeterReadsGasResponseDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.MeterReadsResponseDto;
-import com.alliander.osgp.dto.valueobjects.smartmetering.ObisCodeValuesDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodTypeDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadGasResponseDto;
 import com.alliander.osgp.dto.valueobjects.smartmetering.PeriodicMeterReadsRequestDto;
@@ -302,10 +301,8 @@ public class MonitoringService {
         final SmartMeter smartMeter = this.domainHelperService.findSmartMeter(deviceMessageMetadata
                 .getDeviceIdentification());
 
-        final ObisCodeValuesDto obisCodeDto = this.monitoringMapper.map(request.getObisCode(), ObisCodeValuesDto.class);
-
-        final ProfileGenericDataRequestDto requestDto = new ProfileGenericDataRequestDto(
-                request.getDeviceIdentification(), obisCodeDto, request.getBeginDate(), request.getEndDate());
+        final ProfileGenericDataRequestDto requestDto = this.monitoringMapper.map(request,
+                ProfileGenericDataRequestDto.class);
 
         final RequestMessage requestMessage = new RequestMessage(deviceMessageMetadata.getCorrelationUid(),
                 deviceMessageMetadata.getOrganisationIdentification(), deviceMessageMetadata.getDeviceIdentification(),
@@ -327,7 +324,7 @@ public class MonitoringService {
             result = ResponseMessageResultType.NOT_OK;
         }
 
-        ProfileGenericDataResponse responseVo = this.monitoringMapper.map(profileGenericDataResponseDto,
+        final ProfileGenericDataResponse responseVo = this.monitoringMapper.map(profileGenericDataResponseDto,
                 ProfileGenericDataResponse.class);
 
         this.webServiceResponseMessageSender.send(new ResponseMessage(deviceMessageMetadata.getCorrelationUid(),

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/mapping/MonitoringMapper.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/mapping/MonitoringMapper.java
@@ -7,12 +7,13 @@
  */
 package com.alliander.osgp.adapter.ws.smartmetering.application.mapping;
 
-import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.impl.ConfigurableMapper;
-
 import org.springframework.stereotype.Component;
 
+import com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.ProfileGenericDataRequest;
 import com.alliander.osgp.domain.core.valueobjects.smartmetering.AmrProfileStatusCode;
+
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.ConfigurableMapper;
 
 @Component(value = "monitoringMapper")
 public class MonitoringMapper extends ConfigurableMapper {
@@ -44,6 +45,18 @@ public class MonitoringMapper extends ConfigurableMapper {
 
         // This converter is needed because it contains logic.
         mapperFactory.getConverterFactory().registerConverter(new PeriodicReadsRequestGasQueryConverter());
+
+        /*
+         * The XML construct with the selected values is a bit more complex than
+         * the one in the rest of the code. The "selectedValues.captureObject"
+         * in XML is the actual list of the objects to be mapped to the
+         * "selectedValues" in the rest of the code and vice versa.
+         */
+        mapperFactory
+                .classMap(ProfileGenericDataRequest.class,
+                        com.alliander.osgp.domain.core.valueobjects.smartmetering.ProfileGenericDataRequest.class)
+                .fieldAToB("selectedValues.captureObject", "selectedValues")
+                .fieldBToA("selectedValues", "selectedValues.captureObject").byDefault().register();
 
         mapperFactory.getConverterFactory().registerConverter(new ObisCodeValuesConverter());
 

--- a/osgp-core/src/main/java/com/alliander/osgp/core/application/tasks/ScheduledTaskScheduler.java
+++ b/osgp-core/src/main/java/com/alliander/osgp/core/application/tasks/ScheduledTaskScheduler.java
@@ -75,10 +75,16 @@ public class ScheduledTaskScheduler implements Runnable {
                 scheduledTask.getDeviceIdentification(), scheduledTask.getOrganisationIdentification(),
                 scheduledTask.getCorrelationId(), scheduledTask.getMessageType(), scheduledTask.getMessagePriority());
 
+        final String ipAddress;
+        if (device.getNetworkAddress() == null) {
+            ipAddress = null;
+        } else {
+            ipAddress = device.getNetworkAddress().getHostAddress();
+        }
+
         return new ProtocolRequestMessage.Builder().deviceMessageMetadata(deviceMessageMetadata)
-                .domain(scheduledTask.getDomain()).domainVersion(scheduledTask.getDomainVersion())
-                .ipAddress(device.getNetworkAddress().getHostAddress()).request(scheduledTask.getMessageData())
-                .retryCount(scheduledTask.getRetry()).scheduled(true).build();
+                .domain(scheduledTask.getDomain()).domainVersion(scheduledTask.getDomainVersion()).ipAddress(ipAddress)
+                .request(scheduledTask.getMessageData()).retryCount(scheduledTask.getRetry()).scheduled(true).build();
     }
 
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/CaptureObjectDefinition.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/CaptureObjectDefinition.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2017 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.domain.core.valueobjects.smartmetering;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class CaptureObjectDefinition implements Serializable {
+
+    private static final long serialVersionUID = -1155157491281654400L;
+
+    private final int classId;
+    private final ObisCodeValues logicalName;
+    private final byte attributeIndex;
+    private final Integer dataIndex;
+
+    public CaptureObjectDefinition(final int classId, final ObisCodeValues logicalName, final byte attributeIndex,
+            final Integer dataIndex) {
+        this.classId = classId;
+        this.logicalName = logicalName;
+        this.attributeIndex = attributeIndex;
+        this.dataIndex = dataIndex;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{ %d, %s, %d, %d }", this.classId, this.logicalName, this.attributeIndex,
+                this.dataIndex == null ? 0 : this.dataIndex);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CaptureObjectDefinition)) {
+            return false;
+        }
+        final CaptureObjectDefinition other = (CaptureObjectDefinition) obj;
+        return this.classId == other.classId && Objects.equals(this.logicalName, other.logicalName)
+                && this.attributeIndex == other.attributeIndex && Objects.equals(this.dataIndex, other.dataIndex);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.classId, this.logicalName, this.attributeIndex, this.dataIndex);
+    }
+
+    public int getClassId() {
+        return this.classId;
+    }
+
+    public ObisCodeValues getLogicalName() {
+        return this.logicalName;
+    }
+
+    public byte getAttributeIndex() {
+        return this.attributeIndex;
+    }
+
+    public Integer getDataIndex() {
+        return this.dataIndex;
+    }
+}

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ObisCodeValues.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ObisCodeValues.java
@@ -10,6 +10,7 @@
 package com.alliander.osgp.domain.core.valueobjects.smartmetering;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class ObisCodeValues implements Serializable {
 
@@ -23,7 +24,6 @@ public class ObisCodeValues implements Serializable {
     private byte f;
 
     public ObisCodeValues(final byte a, final byte b, final byte c, final byte d, final byte e, final byte f) {
-        super();
         this.a = a;
         this.b = b;
         this.c = c;
@@ -57,16 +57,14 @@ public class ObisCodeValues implements Serializable {
     }
 
     @Override
+    public String toString() {
+        return String.format("%d.%d.%d.%d.%d.%d", this.a & 0xFF, this.b & 0xFF, this.c & 0xFF, this.d & 0xFF,
+                this.e & 0xFF, this.f & 0xFF);
+    }
+
+    @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + this.a;
-        result = prime * result + this.b;
-        result = prime * result + this.c;
-        result = prime * result + this.d;
-        result = prime * result + this.e;
-        result = prime * result + this.f;
-        return result;
+        return Objects.hash(this.a, this.b, this.c, this.d, this.e, this.f);
     }
 
     @Override
@@ -74,31 +72,11 @@ public class ObisCodeValues implements Serializable {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
-            return false;
-        }
-        if (this.getClass() != obj.getClass()) {
+        if (!(obj instanceof ObisCodeValues)) {
             return false;
         }
         final ObisCodeValues other = (ObisCodeValues) obj;
-        if (this.a != other.a) {
-            return false;
-        }
-        if (this.b != other.b) {
-            return false;
-        }
-        if (this.c != other.c) {
-            return false;
-        }
-        if (this.d != other.d) {
-            return false;
-        }
-        if (this.e != other.e) {
-            return false;
-        }
-        if (this.f != other.f) {
-            return false;
-        }
-        return true;
+        return this.a == other.a && this.b == other.b && this.c == other.c && this.d == other.d && this.e == other.e
+                && this.f == other.f;
     }
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ProfileGenericDataRequest.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ProfileGenericDataRequest.java
@@ -10,7 +10,11 @@
 package com.alliander.osgp.domain.core.valueobjects.smartmetering;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 
 import com.alliander.osgp.domain.core.valueobjects.DeviceFunction;
 import com.alliander.osgp.shared.exceptionhandling.FunctionalException;
@@ -23,13 +27,22 @@ public class ProfileGenericDataRequest implements Serializable, ActionRequest {
     private final ObisCodeValues obisCode;
     private final Date beginDate;
     private final Date endDate;
+    private final List<CaptureObjectDefinition> selectedValues = new ArrayList<>();
+
+    public ProfileGenericDataRequest(final ObisCodeValues obisCode, final Date beginDate, final Date endDate,
+            final List<CaptureObjectDefinition> selectedValues, final String deviceIdentification) {
+        this.deviceIdentification = deviceIdentification;
+        this.obisCode = obisCode;
+        this.beginDate = new Date(beginDate.getTime());
+        this.endDate = new Date(endDate.getTime());
+        if (selectedValues != null) {
+            this.selectedValues.addAll(selectedValues);
+        }
+    }
 
     public ProfileGenericDataRequest(final ObisCodeValues obisCode, final Date beginDate, final Date endDate,
             final String deviceIdentification) {
-        this.deviceIdentification = deviceIdentification;
-        this.obisCode = obisCode;
-        this.beginDate = beginDate;
-        this.endDate = endDate;
+        this(obisCode, beginDate, endDate, Collections.emptyList(), deviceIdentification);
     }
 
     public String getDeviceIdentification() {
@@ -41,11 +54,15 @@ public class ProfileGenericDataRequest implements Serializable, ActionRequest {
     }
 
     public Date getBeginDate() {
-        return this.beginDate;
+        return new Date(this.beginDate.getTime());
     }
 
     public Date getEndDate() {
-        return this.endDate;
+        return new Date(this.endDate.getTime());
+    }
+
+    public List<CaptureObjectDefinition> getSelectedValues() {
+        return new ArrayList<>(this.selectedValues);
     }
 
     @Override
@@ -59,56 +76,32 @@ public class ProfileGenericDataRequest implements Serializable, ActionRequest {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((this.beginDate == null) ? 0 : this.beginDate.hashCode());
-        result = prime * result + ((this.deviceIdentification == null) ? 0 : this.deviceIdentification.hashCode());
-        result = prime * result + ((this.endDate == null) ? 0 : this.endDate.hashCode());
-        result = prime * result + ((this.obisCode == null) ? 0 : this.obisCode.hashCode());
-        return result;
+    public String toString() {
+        return String.format(
+                "%s[device=%s, obisCode=%s, begin=%tF %<tT.%<tL %<tZ, end=%tF %<tT.%<tL %<tZ, selected=%s]",
+                ProfileGenericDataRequest.class.getSimpleName(), this.deviceIdentification, this.obisCode,
+                this.beginDate, this.endDate,
+                this.selectedValues.isEmpty() ? "all capture objects" : this.selectedValues);
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public int hashCode() {
+        return Objects.hash(this.deviceIdentification, this.obisCode, this.beginDate, this.endDate,
+                this.selectedValues);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
+        if (!(obj instanceof ProfileGenericDataRequest)) {
             return false;
         }
-        if (this.getClass() != obj.getClass()) {
-            return false;
-        }
-        ProfileGenericDataRequest other = (ProfileGenericDataRequest) obj;
-        if (this.beginDate == null) {
-            if (other.beginDate != null) {
-                return false;
-            }
-        } else if (!this.beginDate.equals(other.beginDate)) {
-            return false;
-        }
-        if (this.deviceIdentification == null) {
-            if (other.deviceIdentification != null) {
-                return false;
-            }
-        } else if (!this.deviceIdentification.equals(other.deviceIdentification)) {
-            return false;
-        }
-        if (this.endDate == null) {
-            if (other.endDate != null) {
-                return false;
-            }
-        } else if (!this.endDate.equals(other.endDate)) {
-            return false;
-        }
-        if (this.obisCode == null) {
-            if (other.obisCode != null) {
-                return false;
-            }
-        } else if (!this.obisCode.equals(other.obisCode)) {
-            return false;
-        }
-        return true;
+        final ProfileGenericDataRequest other = (ProfileGenericDataRequest) obj;
+        return Objects.equals(this.deviceIdentification, other.deviceIdentification)
+                && Objects.equals(this.obisCode, other.obisCode) && Objects.equals(this.beginDate, other.beginDate)
+                && Objects.equals(this.endDate, other.endDate)
+                && Objects.equals(this.selectedValues, other.selectedValues);
     }
 }


### PR DESCRIPTION
Brings selective access for profile generic to the
command executor.

* Adds value object for CaptureObjectDefinition.
* Adds toString to ObisCodeValues.
* Cleans up equals and hashCode for ObisCodeValues.
* Adds selectedValues to ProfileGenericDataRequest.
* Makes ProfileGenericDataRequest properly immutable.
* Adds toString to ProfileGenericDataRequest.
* Cleans up ProfileGenericDataRequest equals and hashCode.
* Simplifies mapping to ProfileGenericDataRequestDto.
* Configures MonitoringMapper to be able to map
  selectedValues.