### PR TITLE
OC-305 Use OSGP client certificate to send notifications

### DIFF
--- a/osgp-adapter-ws-microgrids/src/main/java/com/alliander/osgp/adapter/ws/microgrids/application/config/WebServiceConfig.java
+++ b/osgp-adapter-ws-microgrids/src/main/java/com/alliander/osgp/adapter/ws/microgrids/application/config/WebServiceConfig.java
@@ -74,6 +74,9 @@ public class WebServiceConfig extends AbstractConfig {
     @Value("${web.service.notification.username:#{null}}")
     private String webserviceNotificationUsername;
 
+    @Value("${web.service.notification.organisation:OSGP}")
+    private String webserviceNotificationOrganisation;
+
     @Value("${web.service.keystore.type}")
     private String webserviceKeystoreType;
 
@@ -215,7 +218,7 @@ public class WebServiceConfig extends AbstractConfig {
     public NotificationService wsSmartMeteringNotificationService() throws GeneralSecurityException {
         if (this.webserviceNotificationEnabled && !StringUtils.isEmpty(this.webserviceNotificationUrl)) {
             return new NotificationServiceWs(this.sendNotificationServiceClient(), this.webserviceNotificationUrl,
-                    this.webserviceNotificationUsername);
+                    this.webserviceNotificationUsername, this.webserviceNotificationOrganisation);
         } else {
             return new NotificationServiceBlackHole();
         }

--- a/osgp-adapter-ws-microgrids/src/main/java/com/alliander/osgp/adapter/ws/microgrids/application/services/NotificationServiceWs.java
+++ b/osgp-adapter-ws-microgrids/src/main/java/com/alliander/osgp/adapter/ws/microgrids/application/services/NotificationServiceWs.java
@@ -29,11 +29,14 @@ public class NotificationServiceWs implements NotificationService {
 
     private final String notificationUsername;
 
+    private final String notificationOrganisation;
+
     public NotificationServiceWs(final SendNotificationServiceClient client, final String notificationUrl,
-            final String notificationUsername) {
+            final String notificationUsername, final String notificationOrganisation) {
         this.sendNotificationServiceClient = client;
         this.notificationUrl = notificationUrl;
         this.notificationUsername = notificationUsername;
+        this.notificationOrganisation = notificationOrganisation;
     }
 
     /*
@@ -50,8 +53,8 @@ public class NotificationServiceWs implements NotificationService {
             final String result, final String correlationUid, final String message,
             final NotificationType notificationType) {
 
-        LOGGER.info("sendNotification called with organisation: {}, correlationUid: {}, type: {}",
-                organisationIdentification, correlationUid, notificationType);
+        LOGGER.info("sendNotification called with organisation: {}, correlationUid: {}, type: {}, to organisation: {}",
+                this.notificationOrganisation, correlationUid, notificationType, organisationIdentification);
 
         final Notification notification = new Notification();
         // message is null, unless an error occurred
@@ -62,7 +65,12 @@ public class NotificationServiceWs implements NotificationService {
         notification.setNotificationType(notificationType);
 
         try {
-            this.sendNotificationServiceClient.sendNotification(organisationIdentification, notification,
+            /*
+             * Get a template for the organisation representing the OSGP
+             * platform, on behalf of which the notification is sent to the
+             * organisation identified by the organisationIdentification.
+             */
+            this.sendNotificationServiceClient.sendNotification(this.notificationOrganisation, notification,
                     this.notificationUrl, this.notificationUsername);
         } catch (final WebServiceSecurityException e) {
             LOGGER.error(e.getMessage(), e);

--- a/osgp-adapter-ws-microgrids/src/main/resources/osgp-adapter-ws-microgrids.properties
+++ b/osgp-adapter-ws-microgrids/src/main/resources/osgp-adapter-ws-microgrids.properties
@@ -15,6 +15,7 @@ jaxb2.marshaller.context.path.microgrids.notification=com.alliander.osgp.adapter
 #Notification url
 web.service.notification.url=http://localhost:8088/mockMicrogridsNotificationPortSoap11
 web.service.notification.username=test-org
+web.service.notification.organisation=OSGP
 web.service.notification.enabled=true
 
 stub.responses=false

--- a/osgp-adapter-ws-shared/src/main/java/com/alliander/osgp/adapter/ws/shared/services/AbstractNotificationServiceWs.java
+++ b/osgp-adapter-ws-shared/src/main/java/com/alliander/osgp/adapter/ws/shared/services/AbstractNotificationServiceWs.java
@@ -22,10 +22,13 @@ public abstract class AbstractNotificationServiceWs {
 
     protected final String notificationUsername;
     protected final String notificationUrl;
+    protected final String notificationOrganisation;
 
-    protected AbstractNotificationServiceWs(final String notificationUrl, final String notificationUsername) {
+    protected AbstractNotificationServiceWs(final String notificationUrl, final String notificationUsername,
+            final String notificationOrganisation) {
         this.notificationUrl = notificationUrl;
         this.notificationUsername = notificationUsername;
+        this.notificationOrganisation = notificationOrganisation;
     }
 
     protected void doSendNotification(final WebserviceTemplateFactory wsTemplateFactory,
@@ -33,13 +36,19 @@ public abstract class AbstractNotificationServiceWs {
             final Object notification) {
 
         try {
-            final WebServiceTemplate wsTemplate = wsTemplateFactory.getTemplate(organisationIdentification, userName,
+            /*
+             * Get a template for the organisation representing the OSGP
+             * platform, on behalf of which the notification is sent to the
+             * organisation identified by the organisationIdentification.
+             */
+            final WebServiceTemplate wsTemplate = wsTemplateFactory.getTemplate(this.notificationOrganisation, userName,
                     notificationURL);
             wsTemplate.marshalSendAndReceive(notification);
         } catch (WebServiceTransportException | WebServiceSecurityException e) {
             final String msg = String.format(
-                    "error sending notification message org=%s, user=%s, notifyUrl=%s, errmsg=%s",
-                    organisationIdentification, userName, notificationURL, e.getMessage());
+                    "error sending notification message org=%s, user=%s, to org=%s, notifyUrl=%s, errmsg=%s",
+                    this.notificationOrganisation, userName, organisationIdentification, notificationURL,
+                    e.getMessage());
             LOGGER.error(msg, e);
         }
 

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/config/WebServiceConfig.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/config/WebServiceConfig.java
@@ -95,6 +95,9 @@ public class WebServiceConfig extends AbstractConfig {
     @Value("${web.service.notification.username:#{null}}")
     private String webserviceNotificationUsername;
 
+    @Value("${web.service.notification.organisation:OSGP}")
+    private String webserviceNotificationOrganisation;
+
     @Value("${application.name}")
     private String applicationName;
 
@@ -168,10 +171,15 @@ public class WebServiceConfig extends AbstractConfig {
     }
 
     @Bean
+    public String notificationOrganisation() {
+        return this.webserviceNotificationOrganisation;
+    }
+
+    @Bean
     public NotificationService wsSmartMeteringNotificationService() throws GeneralSecurityException {
         if (this.webserviceNotificationEnabled) {
             return new NotificationServiceWs(this.createWebServiceTemplateFactory(this.notificationSenderMarshaller()),
-                    this.notificationUrl(), this.notificationUsername());
+                    this.notificationUrl(), this.notificationUsername(), this.notificationOrganisation());
         } else {
             return new NotificationServiceBlackHole();
         }

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/services/NotificationServiceWs.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/services/NotificationServiceWs.java
@@ -34,8 +34,8 @@ public class NotificationServiceWs extends AbstractNotificationServiceWs impleme
 
     @Autowired
     public NotificationServiceWs(final DefaultWebServiceTemplateFactory webServiceTemplateFactory,
-            final String notificationUrl, final String notificationUsername) {
-        super(notificationUrl, notificationUsername);
+            final String notificationUrl, final String notificationUsername, final String notificationOrganisation) {
+        super(notificationUrl, notificationUsername, notificationOrganisation);
         this.webServiceTemplateFactory = webServiceTemplateFactory;
     }
 

--- a/osgp-adapter-ws-smartmetering/src/main/resources/osgp-adapter-ws-smartmetering.properties
+++ b/osgp-adapter-ws-smartmetering/src/main/resources/osgp-adapter-ws-smartmetering.properties
@@ -124,6 +124,7 @@ jaxb2.marshaller.context.path.smartmetering.notification=com.alliander.osgp.adap
 web.service.notification.enabled=true
 web.service.notification.url=https://localhost/sm-integration/smartMetering/notificationService/SmartMeteringNotification
 web.service.notification.username=test-org
+web.service.notification.organisation=OSGP
 
 #Apache client
 apache.client.max.connections.per.route=20


### PR DESCRIPTION
Uses OSGP client certificate for notifications.

* Adds web.service.notification.organisation to
  smartmetering ws configuration properties
* Adds web.service.notification.organisation to
  microgrids ws configuration properties
* Configures the NotificationServiceWS for
  smartmetering and microgrids to use the configured
  organisation (OSGP) for the web service template
  for sending notifications.