### PR TITLE
SLIM-873 Fixes Orika converter after upgrade to 1.5.1

### DIFF
--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/mapping/PeriodicMeterReadsRequestConverter.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/mapping/PeriodicMeterReadsRequestConverter.java
@@ -19,6 +19,11 @@ public class PeriodicMeterReadsRequestConverter extends
         CustomConverter<com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring.PeriodicReadsRequest, PeriodicMeterReadsQuery> {
 
     @Override
+    public boolean canConvert(final Type<?> sourceType, final Type<?> destinationType) {
+        return this.sourceType.isAssignableFrom(sourceType) && this.destinationType.equals(destinationType);
+    }
+
+    @Override
     public PeriodicMeterReadsQuery convert(final PeriodicReadsRequest source,
             final Type<? extends PeriodicMeterReadsQuery> destinationType, final MappingContext context) {
         return new PeriodicMeterReadsQuery(


### PR DESCRIPTION
Adds the canConvert implementation according to the 1.4.6
version of Orika to the PeriodicMeterReadsRequestConverter.
With the 1.5.1 version in the CustomConverter the mapping of
the WS PeriodicReadsRequest does not use this converter and
fails.