### PR TITLE
DA-142 Notification service should use OSGP client-certificate. Same …

### DIFF
--- a/osgp-adapter-ws-distributionautomation/src/main/java/org/osgpfoundation/osgp/adapter/ws/da/application/config/WebServiceConfig.java
+++ b/osgp-adapter-ws-distributionautomation/src/main/java/org/osgpfoundation/osgp/adapter/ws/da/application/config/WebServiceConfig.java
@@ -71,6 +71,8 @@ public class WebServiceConfig extends AbstractConfig {
     private String webserviceNotificationUrl;
     @Value("${web.service.notification.username:#{null}}")
     private String webserviceNotificationUsername;
+    @Value("${web.service.notification.organisation:OSGP}")
+    private String webserviceNotificationOrganisation;
     @Value("${web.service.keystore.type}")
     private String webserviceKeystoreType;
     @Value("${web.service.keystore.location}")
@@ -195,7 +197,7 @@ public class WebServiceConfig extends AbstractConfig {
     public NotificationService wsSmartMeteringNotificationService() throws GeneralSecurityException {
         if (this.webserviceNotificationEnabled && !StringUtils.isEmpty(this.webserviceNotificationUrl)) {
             return new NotificationServiceWs(this.sendNotificationServiceClient(), this.webserviceNotificationUrl,
-                    this.webserviceNotificationUsername);
+                    this.webserviceNotificationUsername, this.webserviceNotificationOrganisation);
         } else {
             return new NotificationServiceBlackHole();
         }

--- a/osgp-adapter-ws-distributionautomation/src/main/java/org/osgpfoundation/osgp/adapter/ws/da/application/services/NotificationServiceWs.java
+++ b/osgp-adapter-ws-distributionautomation/src/main/java/org/osgpfoundation/osgp/adapter/ws/da/application/services/NotificationServiceWs.java
@@ -28,10 +28,13 @@ public class NotificationServiceWs implements NotificationService {
 
     private final String notificationUsername;
 
-    public NotificationServiceWs(final SendNotificationServiceClient client, final String notificationUrl, final String notificationUsername) {
+    private final String notificationOrganisation;
+
+    public NotificationServiceWs(final SendNotificationServiceClient client, final String notificationUrl, final String notificationUsername, final String notificationOrganisation) {
         this.sendNotificationServiceClient = client;
         this.notificationUrl = notificationUrl;
         this.notificationUsername = notificationUsername;
+        this.notificationOrganisation = notificationOrganisation;
     }
 
     /*
@@ -47,8 +50,8 @@ public class NotificationServiceWs implements NotificationService {
     public void sendNotification(final String organisationIdentification, final String deviceIdentification, final String result,
                                  final String correlationUid, final String message, final NotificationType notificationType) {
 
-        LOGGER.info("sendNotification called with organisation: {}, correlationUid: {}, type: {}", organisationIdentification, correlationUid,
-                notificationType);
+        LOGGER.info("sendNotification called with organisation: {}, correlationUid: {}, type: {}, to organisation: {}",
+                this.notificationOrganisation, correlationUid, notificationType, organisationIdentification);
 
         final Notification notification = new Notification();
         // message is null, unless an error occurred
@@ -59,8 +62,13 @@ public class NotificationServiceWs implements NotificationService {
         notification.setNotificationType(notificationType);
 
         try {
-            this.sendNotificationServiceClient
-                    .sendNotification(organisationIdentification, notification, this.notificationUrl, this.notificationUsername);
+            /*
+             * Get a template for the organisation representing the OSGP
+             * platform, on behalf of which the notification is sent to the
+             * organisation identified by the organisationIdentification.
+             */
+            this.sendNotificationServiceClient.sendNotification(this.notificationOrganisation, notification,
+                    this.notificationUrl, this.notificationUsername);
         } catch (final WebServiceSecurityException e) {
             LOGGER.error(e.getMessage(), e);
         }

--- a/osgp-adapter-ws-distributionautomation/src/main/resources/osgp-adapter-ws-distributionautomation.properties
+++ b/osgp-adapter-ws-distributionautomation/src/main/resources/osgp-adapter-ws-distributionautomation.properties
@@ -15,6 +15,7 @@ jaxb2.marshaller.context.path.distributionautomation.notification=org.osgpfounda
 #Notification url
 web.service.notification.url=https://localhost/ws/da-notification
 web.service.notification.username=test-org
+web.service.notification.organisation=OSGP
 web.service.notification.enabled=true
 
 # =========================================================


### PR DESCRIPTION
OC-305 has changed the certificate for notification services for other domains. This pull request does the same changes only for distributionautomation.