### PR TITLE
Slim 976 couple unbound connected

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-976_Couple_unbound_connected

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MBusGatewayService.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MBusGatewayService.java
@@ -116,11 +116,12 @@ public class MBusGatewayService {
             this.installationService.handleResponse("deCoupleMbusDevice", deviceMessageMetadata,
                     ResponseMessageResultType.OK, null);
         } else {
-            final DeCoupleMbusDeviceDto decoupleMbusDto = new DeCoupleMbusDeviceDto(mbusDeviceIdentification,
+            final DeCoupleMbusDeviceDto deCoupleMbusDeviceDto = new DeCoupleMbusDeviceDto(mbusDeviceIdentification,
                     mbusDevice.getChannel());
             final RequestMessage requestMessage = new RequestMessage(deviceMessageMetadata.getCorrelationUid(),
                     deviceMessageMetadata.getOrganisationIdentification(),
-                    deviceMessageMetadata.getDeviceIdentification(), gatewayDevice.getIpAddress(), decoupleMbusDto);
+                    deviceMessageMetadata.getDeviceIdentification(), gatewayDevice.getIpAddress(),
+                    deCoupleMbusDeviceDto);
             this.osgpCoreRequestMessageSender.send(requestMessage, deviceMessageMetadata.getMessageType(),
                     deviceMessageMetadata.getMessagePriority(), deviceMessageMetadata.getScheduleTime());
         }
@@ -231,8 +232,18 @@ public class MBusGatewayService {
         final String mbusManufacturerIdentification = mbusDevice.getMbusManufacturerIdentification();
         final Short mbusVersion = mbusDevice.getMbusVersion();
         final Short mbusDeviceTypeIdentification = mbusDevice.getMbusDeviceTypeIdentification();
+        Short channel = mbusDevice.getChannel();
+        Short primaryAddress = mbusDevice.getMbusPrimaryAddress();
 
-        return new MbusChannelElementsDto(mbusDeviceIdentification, mbusIdentificationNumber,
+        if (channel == null) { // TODO remove
+            channel = 1;
+        }
+
+        if (primaryAddress == null) { // TODO remove
+            primaryAddress = 3;
+        }
+
+        return new MbusChannelElementsDto(channel, primaryAddress, mbusDeviceIdentification, mbusIdentificationNumber,
                 mbusManufacturerIdentification, mbusVersion, mbusDeviceTypeIdentification);
     }
 

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MBusGatewayService.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MBusGatewayService.java
@@ -84,8 +84,8 @@ public class MBusGatewayService {
 
             this.checkAndHandleInactiveMbusDevice(mbusDevice);
             this.checkAndHandleIfGivenMBusAlreadyCoupled(mbusDevice);
-            final MbusChannelElementsDto mbusChannelElementsDto = this.makeMbusChannelElementsDto(mbusDevice); // send
-                                                                                                               // primaryadress
+            final MbusChannelElementsDto mbusChannelElementsDto = this.makeMbusChannelElementsDto(mbusDevice);
+
             final RequestMessage requestMessage = new RequestMessage(deviceMessageMetadata.getCorrelationUid(),
                     deviceMessageMetadata.getOrganisationIdentification(),
                     deviceMessageMetadata.getDeviceIdentification(), gatewayDevice.getIpAddress(),
@@ -233,14 +233,13 @@ public class MBusGatewayService {
         final String mbusManufacturerIdentification = mbusDevice.getMbusManufacturerIdentification();
         final Short mbusVersion = mbusDevice.getMbusVersion();
         final Short mbusDeviceTypeIdentification = mbusDevice.getMbusDeviceTypeIdentification();
-        final Short channel = mbusDevice.getChannel();
         Short primaryAddress = null;
 
         if (mbusDevice.getMbusPrimaryAddress() != null) {
             primaryAddress = mbusDevice.getMbusPrimaryAddress();
         }
 
-        return new MbusChannelElementsDto(channel, primaryAddress, mbusDeviceIdentification, mbusIdentificationNumber,
+        return new MbusChannelElementsDto(primaryAddress, mbusDeviceIdentification, mbusIdentificationNumber,
                 mbusManufacturerIdentification, mbusVersion, mbusDeviceTypeIdentification);
     }
 
@@ -324,7 +323,8 @@ public class MBusGatewayService {
 
     private short getPrimaryAddress(final MbusChannelElementsResponseDto mbusChannelElementsResponseDto,
             final short channel) {
-        // because the List is 0-based, we need to subtract 1
+        // because the List is 0-based, it is needed to subtract 1 to get the
+        // ChannelElements for the desired channel.
         return mbusChannelElementsResponseDto.getRetrievedChannelElements().get(channel - 1).getPrimaryAddress();
     }
 }

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MBusGatewayService.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/MBusGatewayService.java
@@ -84,7 +84,8 @@ public class MBusGatewayService {
 
             this.checkAndHandleInactiveMbusDevice(mbusDevice);
             this.checkAndHandleIfGivenMBusAlreadyCoupled(mbusDevice);
-            final MbusChannelElementsDto mbusChannelElementsDto = this.makeMbusChannelElementsDto(mbusDevice);
+            final MbusChannelElementsDto mbusChannelElementsDto = this.makeMbusChannelElementsDto(mbusDevice); // send
+                                                                                                               // primaryadress
             final RequestMessage requestMessage = new RequestMessage(deviceMessageMetadata.getCorrelationUid(),
                     deviceMessageMetadata.getOrganisationIdentification(),
                     deviceMessageMetadata.getDeviceIdentification(), gatewayDevice.getIpAddress(),
@@ -232,15 +233,11 @@ public class MBusGatewayService {
         final String mbusManufacturerIdentification = mbusDevice.getMbusManufacturerIdentification();
         final Short mbusVersion = mbusDevice.getMbusVersion();
         final Short mbusDeviceTypeIdentification = mbusDevice.getMbusDeviceTypeIdentification();
-        Short channel = mbusDevice.getChannel();
-        Short primaryAddress = mbusDevice.getMbusPrimaryAddress();
+        final Short channel = mbusDevice.getChannel();
+        Short primaryAddress = null;
 
-        if (channel == null) { // TODO remove
-            channel = 1;
-        }
-
-        if (primaryAddress == null) { // TODO remove
-            primaryAddress = 3;
+        if (mbusDevice.getMbusPrimaryAddress() != null) {
+            primaryAddress = mbusDevice.getMbusPrimaryAddress();
         }
 
         return new MbusChannelElementsDto(channel, primaryAddress, mbusDeviceIdentification, mbusIdentificationNumber,

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/CoupleMbusDeviceRequestMessageProcessor.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/CoupleMbusDeviceRequestMessageProcessor.java
@@ -9,6 +9,7 @@
 package com.alliander.osgp.adapter.domain.smartmetering.infra.jms.ws.messageprocessors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.domain.smartmetering.application.services.InstallationService;
@@ -26,6 +27,7 @@ import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
 public class CoupleMbusDeviceRequestMessageProcessor extends WebServiceRequestMessageProcessor {
 
     @Autowired
+    @Qualifier("domainSmartMeteringInstallationService")
     private InstallationService installationService;
 
     protected CoupleMbusDeviceRequestMessageProcessor() {


### PR DESCRIPTION
Added for coupling channel and primaryaddress, since they are needed for coupling unbound devices.