### PR TITLE
SLIM-1222 Fix end-to-end FirmwareUpdate

### DIFF
--- a/osgp-core/src/main/java/com/alliander/osgp/core/infra/jms/protocol/in/messageprocessors/GetFirmwareFileMessageProcessor.java
+++ b/osgp-core/src/main/java/com/alliander/osgp/core/infra/jms/protocol/in/messageprocessors/GetFirmwareFileMessageProcessor.java
@@ -73,7 +73,7 @@ public class GetFirmwareFileMessageProcessor extends ProtocolRequestMessageProce
             final FirmwareFile firmwareFile = this.firmwareFileRepository
                     .findByIdentification(firmwareFileIdentification);
 
-            final FirmwareFileDto firmwareFileDto = new FirmwareFileDto(firmwareFile.getFilename(),
+            final FirmwareFileDto firmwareFileDto = new FirmwareFileDto(firmwareFile.getIdentification(),
                     firmwareFile.getFile());
 
             this.sendSuccesResponse(metadata, device.getProtocolInfo(), firmwareFileDto);


### PR DESCRIPTION
The FirmwareFileDto needs identification and file bytes of a firmware
file. The identification used to be by filename, but this was no longer
considered to be a unique identifier.