### PR TITLE
SLIM-1534 Resolves SonarQube reported bugs and vulnerabilities

### DIFF
--- a/osgp-adapter-domain-core/src/main/java/com/alliander/osgp/adapter/domain/core/application/services/AbstractService.java
+++ b/osgp-adapter-domain-core/src/main/java/com/alliander/osgp/adapter/domain/core/application/services/AbstractService.java
@@ -16,9 +16,7 @@ import com.alliander.osgp.adapter.domain.core.infra.jms.ws.WebServiceResponseMes
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
 import com.alliander.osgp.domain.core.entities.Ssld;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.repositories.SsldRepository;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
@@ -49,15 +47,7 @@ public class AbstractService {
     protected WebServiceResponseMessageSender webServiceResponseMessageSender;
 
     protected Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, ComponentType.DOMAIN_CORE, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, ComponentType.DOMAIN_CORE, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, ComponentType.DOMAIN_CORE);
     }
 
     protected Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-domain-distributionautomation/src/main/java/org/osgpfoundation/osgp/adapter/domain/da/application/services/BaseService.java
+++ b/osgp-adapter-domain-distributionautomation/src/main/java/org/osgpfoundation/osgp/adapter/domain/da/application/services/BaseService.java
@@ -9,11 +9,23 @@
  */
 package org.osgpfoundation.osgp.adapter.domain.da.application.services;
 
+import java.util.UUID;
+
+import javax.persistence.OptimisticLockException;
+
+import org.joda.time.DateTime;
+import org.osgpfoundation.osgp.adapter.domain.da.application.mapping.DomainDistributionAutomationMapper;
+import org.osgpfoundation.osgp.adapter.domain.da.infra.jms.core.OsgpCoreRequestMessageSender;
+import org.osgpfoundation.osgp.adapter.domain.da.infra.jms.ws.WebServiceResponseMessageSender;
+import org.osgpfoundation.osgp.domain.da.entities.RtuDevice;
+import org.osgpfoundation.osgp.domain.da.repositories.RtuDeviceRepository;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
@@ -21,18 +33,6 @@ import com.alliander.osgp.shared.exceptionhandling.FunctionalException;
 import com.alliander.osgp.shared.exceptionhandling.FunctionalExceptionType;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
 import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
-import org.osgpfoundation.osgp.adapter.domain.da.infra.jms.core.OsgpCoreRequestMessageSender;
-import org.osgpfoundation.osgp.adapter.domain.da.infra.jms.ws.WebServiceResponseMessageSender;
-import org.osgpfoundation.osgp.domain.da.entities.RtuDevice;
-import org.osgpfoundation.osgp.domain.da.repositories.RtuDeviceRepository;
-import org.joda.time.DateTime;
-import org.osgpfoundation.osgp.adapter.domain.da.application.mapping.DomainDistributionAutomationMapper;
-import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-
-import javax.persistence.OptimisticLockException;
-import java.util.UUID;
 
 public class BaseService {
 
@@ -60,15 +60,8 @@ public class BaseService {
     private Integer lastCommunicationUpdateInterval;
 
     protected Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, ComponentType.DOMAIN_DISTRIBUTION_AUTOMATION, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, ComponentType.DOMAIN_DISTRIBUTION_AUTOMATION, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification,
+                ComponentType.DOMAIN_DISTRIBUTION_AUTOMATION);
     }
 
     protected Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-domain-microgrids/src/main/java/com/alliander/osgp/adapter/domain/microgrids/application/services/BaseService.java
+++ b/osgp-adapter-domain-microgrids/src/main/java/com/alliander/osgp/adapter/domain/microgrids/application/services/BaseService.java
@@ -15,9 +15,7 @@ import com.alliander.osgp.adapter.domain.microgrids.infra.jms.core.OsgpCoreReque
 import com.alliander.osgp.adapter.domain.microgrids.infra.jms.ws.WebServiceResponseMessageSender;
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
 import com.alliander.osgp.domain.microgrids.entities.RtuDevice;
@@ -51,16 +49,7 @@ public class BaseService {
     protected WebServiceResponseMessageSender webServiceResponseMessageSender;
 
     protected Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, ComponentType.DOMAIN_MICROGRIDS,
-                    e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, ComponentType.DOMAIN_MICROGRIDS, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, ComponentType.DOMAIN_MICROGRIDS);
     }
 
     protected Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-domain-publiclighting/src/main/java/com/alliander/osgp/adapter/domain/publiclighting/application/services/AbstractService.java
+++ b/osgp-adapter-domain-publiclighting/src/main/java/com/alliander/osgp/adapter/domain/publiclighting/application/services/AbstractService.java
@@ -16,9 +16,7 @@ import com.alliander.osgp.adapter.domain.publiclighting.infra.jms.ws.WebServiceR
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
 import com.alliander.osgp.domain.core.entities.Ssld;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.repositories.LightMeasurementDeviceRepository;
 import com.alliander.osgp.domain.core.repositories.SsldRepository;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
@@ -53,17 +51,7 @@ public class AbstractService {
     protected WebServiceResponseMessageSender webServiceResponseMessageSender;
 
     protected Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE,
-                    ComponentType.DOMAIN_PUBLIC_LIGHTING, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE,
-                    ComponentType.DOMAIN_PUBLIC_LIGHTING, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, ComponentType.DOMAIN_PUBLIC_LIGHTING);
     }
 
     protected Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-domain-publiclighting/src/main/java/com/alliander/osgp/adapter/domain/publiclighting/application/services/DeviceMonitoringService.java
+++ b/osgp-adapter-domain-publiclighting/src/main/java/com/alliander/osgp/adapter/domain/publiclighting/application/services/DeviceMonitoringService.java
@@ -84,15 +84,20 @@ public class DeviceMonitoringService extends AbstractService {
 
             actualPowerUsageData = this.domainCoreMapper.map(actualPowerUsageDataDto, PowerUsageData.class);
 
+        } catch (final OsgpException e) {
+            /*
+             * Since the domainCoreMapper does not throw OsgpExceptions, this
+             * exception has already been logged in the corresponding try-block.
+             */
+            osgpException = e;
         } catch (final Exception e) {
             LOGGER.error("Unexpected Exception", e);
+            osgpException = new TechnicalException(ComponentType.UNKNOWN,
+                    "Exception occurred while getting device actual power usage", e);
+        }
+
+        if (osgpException != null) {
             result = ResponseMessageResultType.NOT_OK;
-            if (e instanceof OsgpException) {
-                osgpException = (OsgpException) e;
-            } else {
-                osgpException = new TechnicalException(ComponentType.UNKNOWN,
-                        "Exception occurred while getting device actual power usage", e);
-            }
         }
 
         this.webServiceResponseMessageSender.send(new ResponseMessage(correlationUid, organisationIdentification,

--- a/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/DomainHelperService.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/com/alliander/osgp/adapter/domain/smartmetering/application/services/DomainHelperService.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.alliander.osgp.domain.core.entities.SmartMeter;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
 import com.alliander.osgp.domain.core.services.SmartMeterDomainService;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
@@ -51,15 +50,7 @@ public class DomainHelperService {
      *             the device is either not in the database or not active
      */
     public SmartMeter findActiveSmartMeter(final String deviceIdentification) throws FunctionalException {
-        SmartMeter smartMeter;
-        try {
-            smartMeter = this.smartMeteringDeviceDomainService.searchActiveSmartMeter(deviceIdentification);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, COMPONENT_TYPE, e);
-        } catch (final UnknownEntityException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNKNOWN_DEVICE, COMPONENT_TYPE, e);
-        }
-        return smartMeter;
+        return this.smartMeteringDeviceDomainService.searchActiveSmartMeter(deviceIdentification, COMPONENT_TYPE);
     }
 
     public void ensureFunctionalExceptionForUnknownDevice(final String deviceIdentification)

--- a/osgp-adapter-domain-tariffswitching/src/main/java/com/alliander/osgp/adapter/domain/tariffswitching/application/services/AbstractService.java
+++ b/osgp-adapter-domain-tariffswitching/src/main/java/com/alliander/osgp/adapter/domain/tariffswitching/application/services/AbstractService.java
@@ -16,9 +16,7 @@ import com.alliander.osgp.adapter.domain.tariffswitching.infra.jms.ws.WebService
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
 import com.alliander.osgp.domain.core.entities.Ssld;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.repositories.SsldRepository;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
@@ -49,16 +47,7 @@ public class AbstractService {
     protected WebServiceResponseMessageSender webServiceResponseMessageSender;
 
     protected Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE,
-                    ComponentType.DOMAIN_TARIFF_SWITCHING, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, ComponentType.DOMAIN_TARIFF_SWITCHING, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, ComponentType.DOMAIN_TARIFF_SWITCHING);
     }
 
     protected Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-ws-core/src/main/java/com/alliander/osgp/adapter/ws/core/application/services/DomainHelperService.java
+++ b/osgp-adapter-ws-core/src/main/java/com/alliander/osgp/adapter/ws/core/application/services/DomainHelperService.java
@@ -12,10 +12,8 @@ import org.springframework.stereotype.Service;
 
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.NotAuthorizedException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
 import com.alliander.osgp.domain.core.services.SecurityService;
@@ -44,15 +42,7 @@ public class DomainHelperService {
     }
 
     public Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, COMPONENT_TYPE, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, COMPONENT_TYPE, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, COMPONENT_TYPE);
     }
 
     public Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-ws-core/src/main/java/com/alliander/osgp/adapter/ws/core/application/services/FirmwareManagementService.java
+++ b/osgp-adapter-ws-core/src/main/java/com/alliander/osgp/adapter/ws/core/application/services/FirmwareManagementService.java
@@ -482,7 +482,7 @@ public class FirmwareManagementService {
     @Transactional(value = "writableTransactionManager")
     public void addFirmware(@Identification final String organisationIdentification, final String description,
             final byte[] file, final String fileName, final String manufacturer, final String modelCode,
-            final FirmwareModuleData firmwareModuleData, final boolean pushToNewDevices) throws Exception {
+            final FirmwareModuleData firmwareModuleData, final boolean pushToNewDevices) throws OsgpException {
 
         final Organisation organisation = this.domainHelperService.findOrganisation(organisationIdentification);
         this.domainHelperService.isAllowed(organisation, PlatformFunction.CREATE_FIRMWARE);
@@ -562,7 +562,7 @@ public class FirmwareManagementService {
      * Saves a {@link DeviceFirmwareFile} instance.
      */
     @Transactional(value = "writableTransactionManager")
-    public void saveCurrentDeviceFirmwareFile(final DeviceFirmwareFile deviceFirmwareFile) throws Exception {
+    public void saveCurrentDeviceFirmwareFile(final DeviceFirmwareFile deviceFirmwareFile) {
         this.deviceFirmwareFileRepository.save(deviceFirmwareFile);
     }
 
@@ -650,7 +650,7 @@ public class FirmwareManagementService {
      */
     @Transactional(value = "writableTransactionManager")
     public void removeFirmware(@Identification final String organisationIdentification,
-            @Valid final int firmwareIdentification) throws Exception {
+            @Valid final int firmwareIdentification) throws OsgpException {
 
         final Organisation organisation = this.domainHelperService.findOrganisation(organisationIdentification);
         this.domainHelperService.isAllowed(organisation, PlatformFunction.REMOVE_FIRMWARE);
@@ -756,7 +756,7 @@ public class FirmwareManagementService {
             }
         } catch (final NoSuchAlgorithmException e) {
             LOGGER.error("RuntimeException while creating MD5 hash for firmware file.", e);
-            throw new RuntimeException(e);
+            throw new AssertionError("Expected MD5 to be present as algorithm", e);
         }
         return md5Hash;
     }

--- a/osgp-adapter-ws-core/src/main/java/com/alliander/osgp/adapter/ws/core/endpoints/DeviceManagementEndpoint.java
+++ b/osgp-adapter-ws-core/src/main/java/com/alliander/osgp/adapter/ws/core/endpoints/DeviceManagementEndpoint.java
@@ -63,7 +63,6 @@ import com.alliander.osgp.adapter.ws.schema.core.devicemanagement.UpdateDeviceSs
 import com.alliander.osgp.adapter.ws.schema.core.devicemanagement.UpdateDeviceSslCertificationResponse;
 import com.alliander.osgp.domain.core.entities.Organisation;
 import com.alliander.osgp.domain.core.entities.ScheduledTask;
-import com.alliander.osgp.domain.core.exceptions.ArgumentNullOrEmptyException;
 import com.alliander.osgp.domain.core.exceptions.ValidationException;
 import com.alliander.osgp.domain.core.services.CorrelationIdProviderService;
 import com.alliander.osgp.domain.core.valueobjects.Certification;
@@ -271,12 +270,6 @@ public class DeviceManagementEndpoint {
                             .addAll(this.deviceManagementMapper.mapAsList(result.getContent(), Device.class));
                 }
             }
-        } catch (final ArgumentNullOrEmptyException ane) {
-            // TODO: Instead of using this exception, a different solution
-            // should be found to avoid using Exceptions.
-            LOGGER.error("No results found when finding devices", ane);
-            response.setArgument(ane.getArgument());
-            response.setMessage(ane.getMessage());
         } catch (final MethodConstraintViolationException e) {
             LOGGER.error(EXCEPTION, e.getMessage(), e.getStackTrace(), e);
             throw new FunctionalException(FunctionalExceptionType.VALIDATION_ERROR, ComponentType.WS_CORE,

--- a/osgp-adapter-ws-publiclighting/src/main/java/com/alliander/osgp/adapter/ws/publiclighting/application/services/DomainHelperService.java
+++ b/osgp-adapter-ws-publiclighting/src/main/java/com/alliander/osgp/adapter/ws/publiclighting/application/services/DomainHelperService.java
@@ -12,10 +12,8 @@ import org.springframework.stereotype.Service;
 
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.NotAuthorizedException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
 import com.alliander.osgp.domain.core.services.SecurityService;
@@ -44,15 +42,7 @@ public class DomainHelperService {
     }
 
     public Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, COMPONENT_TYPE, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, COMPONENT_TYPE, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, COMPONENT_TYPE);
     }
 
     public Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/services/DomainHelperService.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/services/DomainHelperService.java
@@ -12,10 +12,8 @@ import org.springframework.stereotype.Service;
 
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.NotAuthorizedException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
 import com.alliander.osgp.domain.core.services.SecurityService;
@@ -44,15 +42,7 @@ public class DomainHelperService {
     }
 
     public Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, COMPONENT_TYPE, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, COMPONENT_TYPE, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, COMPONENT_TYPE);
     }
 
     public Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-adapter-ws-tariffswitching/src/main/java/com/alliander/osgp/adapter/ws/tariffswitching/application/services/DomainHelperService.java
+++ b/osgp-adapter-ws-tariffswitching/src/main/java/com/alliander/osgp/adapter/ws/tariffswitching/application/services/DomainHelperService.java
@@ -12,10 +12,8 @@ import org.springframework.stereotype.Service;
 
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.NotAuthorizedException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
 import com.alliander.osgp.domain.core.services.SecurityService;
@@ -44,15 +42,7 @@ public class DomainHelperService {
     }
 
     public Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, COMPONENT_TYPE, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, COMPONENT_TYPE, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, COMPONENT_TYPE);
     }
 
     public Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-core/src/main/java/com/alliander/osgp/core/application/services/DomainHelperService.java
+++ b/osgp-core/src/main/java/com/alliander/osgp/core/application/services/DomainHelperService.java
@@ -12,10 +12,8 @@ import org.springframework.stereotype.Service;
 
 import com.alliander.osgp.domain.core.entities.Device;
 import com.alliander.osgp.domain.core.entities.Organisation;
-import com.alliander.osgp.domain.core.exceptions.InactiveDeviceException;
 import com.alliander.osgp.domain.core.exceptions.NotAuthorizedException;
 import com.alliander.osgp.domain.core.exceptions.UnknownEntityException;
-import com.alliander.osgp.domain.core.exceptions.UnregisteredDeviceException;
 import com.alliander.osgp.domain.core.services.DeviceDomainService;
 import com.alliander.osgp.domain.core.services.OrganisationDomainService;
 import com.alliander.osgp.domain.core.services.SecurityService;
@@ -44,15 +42,7 @@ public class DomainHelperService {
     }
 
     public Device findActiveDevice(final String deviceIdentification) throws FunctionalException {
-        Device device;
-        try {
-            device = this.deviceDomainService.searchActiveDevice(deviceIdentification);
-        } catch (final UnregisteredDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, COMPONENT_TYPE, e);
-        } catch (final InactiveDeviceException e) {
-            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, COMPONENT_TYPE, e);
-        }
-        return device;
+        return this.deviceDomainService.searchActiveDevice(deviceIdentification, COMPONENT_TYPE);
     }
 
     public Organisation findOrganisation(final String organisationIdentification) throws FunctionalException {

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Ssld.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/entities/Ssld.java
@@ -101,6 +101,31 @@ public class Ssld extends Device {
         this.gpsLongitude = longitude;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        /*
+         * Code quality checks indicate that equals should be overridden because
+         * this class extends Device (which overrides equals) and adds fields.
+         *
+         * The equals implementation of Device however is perfectly OK, since it
+         * is based on the deviceIdentification, which is a natural key for
+         * Device as well as its subclasses.
+         *
+         * So, just call super here.
+         */
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        /*
+         * Override hashCode, because equals is overridden as well. This should
+         * get rid of a reported bug by the code quality checks, but the super
+         * implementation is just fine here, like with equals.
+         */
+        return super.hashCode();
+    }
+
     public boolean isPublicKeyPresent() {
         return this.hasPublicKey;
     }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/services/DeviceDomainService.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/services/DeviceDomainService.java
@@ -55,20 +55,22 @@ public class DeviceDomainService {
         return device;
     }
 
-    public Device searchActiveDevice(@Identification final String deviceIdentification)
-            throws UnregisteredDeviceException, InactiveDeviceException, FunctionalException {
+    public Device searchActiveDevice(@Identification final String deviceIdentification, final ComponentType osgpComponent)
+            throws FunctionalException {
 
         final Device device = this.searchDevice(deviceIdentification);
         final Ssld ssld = this.ssldRepository.findOne(device.getId());
 
         if (!device.isActivated() || !device.getDeviceLifecycleStatus().equals(DeviceLifecycleStatus.IN_USE)) {
-            throw new InactiveDeviceException(deviceIdentification);
+            throw new FunctionalException(FunctionalExceptionType.INACTIVE_DEVICE, osgpComponent,
+                    new InactiveDeviceException(deviceIdentification));
         }
 
         // Note: since this code is still specific for SSLD / PSLD, this null
         // check is needed.
         if (ssld != null && !ssld.isPublicKeyPresent()) {
-            throw new UnregisteredDeviceException(deviceIdentification);
+            throw new FunctionalException(FunctionalExceptionType.UNREGISTERED_DEVICE, osgpComponent,
+                    new UnregisteredDeviceException(deviceIdentification));
         }
 
         return device;


### PR DESCRIPTION
Resolves the following potential bug:
* Puts equals implementation in Ssld extending Device.

Resolves the following potential vulnerabilities:
* Use a catch block instead of instanceof in DeviceMonitoringService.
* Throws FunctionalException as only thrown checked exception in
  DeviceManagementService.
* Removes exception or throws a dedicated exception with several methods
  of FirmwareManagementService.
* Throws only one checked exception in DeviceDomainService, changes
  callers to include component type, so the same repeated structure of
  creating a FunctionalException is only in one location.
* Updates the SmartMeterDomainService in a similar way as the
  DeviceDomainService.