### PR TITLE
SLIM-869 Create an integration test https notification service

### DIFF
--- a/osgp-adapter-domain-core/src/main/java/com/alliander/osgp/adapter/domain/core/infra/jms/ws/messageprocessors/CommonSetDeviceLifecycleStatusRequestMessageProcessor.java
+++ b/osgp-adapter-domain-core/src/main/java/com/alliander/osgp/adapter/domain/core/infra/jms/ws/messageprocessors/CommonSetDeviceLifecycleStatusRequestMessageProcessor.java
@@ -48,13 +48,14 @@ public class CommonSetDeviceLifecycleStatusRequestMessageProcessor extends WebSe
         LOGGER.debug("Processing common set device verification key message");
 
         String correlationUid = null;
-        final String messageType = null;
+        String messageType = null;
         String organisationIdentification = null;
         String deviceIdentification = null;
         DeviceLifecycleStatus deviceLifecycleStatus = null;
 
         try {
             correlationUid = message.getJMSCorrelationID();
+            messageType = message.getJMSType();
             organisationIdentification = message.getStringProperty(Constants.ORGANISATION_IDENTIFICATION);
             deviceIdentification = message.getStringProperty(Constants.DEVICE_IDENTIFICATION);
             deviceLifecycleStatus = (DeviceLifecycleStatus) message.getObject();

--- a/osgp-adapter-ws-smartmetering/src/main/resources/osgp-adapter-ws-smartmetering.properties
+++ b/osgp-adapter-ws-smartmetering/src/main/resources/osgp-adapter-ws-smartmetering.properties
@@ -118,7 +118,7 @@ jaxb2.marshaller.context.path.smartmetering.notification=com.alliander.osgp.adap
 
 #Notification url
 web.service.notification.enabled=true
-web.service.notification.url=https://localhost/sm-integration/smartMetering/notificationService/SmartMeteringNotification
+web.service.notification.url=http://localhost:8843/notifications
 web.service.notification.username=test-org
 web.service.notification.organisation=OSGP
 


### PR DESCRIPTION
Changes configuration for notification service URL

The default configuration for the notifications is changed so it matches
the URL where the Cucumber tests will provide a notification service
end-point.