### PR TITLE
Makes BeanFactoryPostProcessor bean static in Spring Configuration

### DIFF
--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/config/ApplicationContext.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/application/config/ApplicationContext.java
@@ -75,7 +75,7 @@ public class ApplicationContext extends AbstractConfig {
     }
 
     @Bean
-    public PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
+    public static PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
         final PropertySourcesPlaceholderConfigurer propertySource = new PropertySourcesPlaceholderConfigurer();
         propertySource.setIgnoreUnresolvablePlaceholders(true);
         return propertySource;


### PR DESCRIPTION
Within a Spring Configuration class bean methods returning an instance
of a class that implements the BeanFactoryPostProcessor interface must
be static to prevent possible issues with some types of annotations.