### PR TITLE
SLIM-1775 Adds value objects for Short IDs on scan M-Bus channels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-1775-Read-all-attributes-on-scan-m-bus-channels
 

--- a/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringAdhocEndpoint.java
+++ b/osgp-adapter-ws-smartmetering/src/main/java/com/alliander/osgp/adapter/ws/smartmetering/endpoints/SmartMeteringAdhocEndpoint.java
@@ -9,6 +9,8 @@
  */
 package com.alliander.osgp.adapter.ws.smartmetering.endpoints;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.server.endpoint.annotation.Endpoint;
 import org.springframework.ws.server.endpoint.annotation.PayloadRoot;
@@ -32,6 +34,7 @@ import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttri
 import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueAsyncResponse;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueRequest;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueResponse;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.MbusChannelShortEquipmentIdentifier;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.ScanMbusChannelsAsyncRequest;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.ScanMbusChannelsAsyncResponse;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc.ScanMbusChannelsRequest;
@@ -307,10 +310,9 @@ public class SmartMeteringAdhocEndpoint extends SmartMeteringEndpoint {
                     .getMessageData();
 
             if (ResponseMessageResultType.OK == responseData.getResultType()) {
-                response.setMbusIdentificationNumber1(scanMbusChannelsResponse.getMbusIdentificationNumber1());
-                response.setMbusIdentificationNumber2(scanMbusChannelsResponse.getMbusIdentificationNumber2());
-                response.setMbusIdentificationNumber3(scanMbusChannelsResponse.getMbusIdentificationNumber3());
-                response.setMbusIdentificationNumber4(scanMbusChannelsResponse.getMbusIdentificationNumber4());
+                final List<MbusChannelShortEquipmentIdentifier> channelShortIds = response.getChannelShortIds();
+                channelShortIds.addAll(this.adhocMapper.mapAsList(scanMbusChannelsResponse.getChannelShortIds(),
+                        MbusChannelShortEquipmentIdentifier.class));
             } else if (responseData.getMessageData() instanceof OsgpException) {
                 throw (OsgpException) responseData.getMessageData();
             } else if (responseData.getMessageData() instanceof Exception) {
@@ -326,4 +328,5 @@ public class SmartMeteringAdhocEndpoint extends SmartMeteringEndpoint {
 
         return response;
     }
+
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/MbusChannelShortEquipmentIdentifier.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/MbusChannelShortEquipmentIdentifier.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.domain.core.valueobjects.smartmetering;
+
+import java.io.Serializable;
+
+public class MbusChannelShortEquipmentIdentifier implements Serializable {
+
+    private static final long serialVersionUID = 8725926156491614715L;
+
+    private final short channel;
+    private final MbusShortEquipmentIdentifier shortId;
+
+    public MbusChannelShortEquipmentIdentifier(final short channel, final MbusShortEquipmentIdentifier shortId) {
+        this.channel = channel;
+        this.shortId = shortId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MbusChannelShortEquipmentIdentifier[channel=%d, shortId=%s]", this.channel, this.shortId);
+    }
+
+    public short getChannel() {
+        return this.channel;
+    }
+
+    public MbusShortEquipmentIdentifier getShortId() {
+        return this.shortId;
+    }
+
+}

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/MbusShortEquipmentIdentifier.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/MbusShortEquipmentIdentifier.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.domain.core.valueobjects.smartmetering;
+
+import java.io.Serializable;
+
+public class MbusShortEquipmentIdentifier implements Serializable {
+
+    private static final long serialVersionUID = -8675174075140715801L;
+
+    private final String identificationNumber;
+    private final String manufacturerIdentification;
+    private final Short versionIdentification;
+    private final Short deviceTypeIdentification;
+
+    public MbusShortEquipmentIdentifier(final String identificationNumber, final String manufacturerIdentification,
+            final Short versionIdentification, final Short deviceTypeIdentification) {
+
+        this.identificationNumber = identificationNumber;
+        this.manufacturerIdentification = manufacturerIdentification;
+        this.versionIdentification = versionIdentification;
+        this.deviceTypeIdentification = deviceTypeIdentification;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "MbusShortEquipmentIdentifier[identificationNumber=%s, manufacturer=%s, version=%d, deviceType=%d]",
+                this.identificationNumber, this.manufacturerIdentification, this.versionIdentification,
+                this.deviceTypeIdentification);
+    }
+
+    public String getIdentificationNumber() {
+        return this.identificationNumber;
+    }
+
+    public String getManufacturerIdentification() {
+        return this.manufacturerIdentification;
+    }
+
+    public Short getVersionIdentification() {
+        return this.versionIdentification;
+    }
+
+    public Short getDeviceTypeIdentification() {
+        return this.deviceTypeIdentification;
+    }
+
+}

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ScanMbusChannelsResponseData.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ScanMbusChannelsResponseData.java
@@ -1,46 +1,35 @@
 /**
  * Copyright 2018 Smart Society Services B.V.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.alliander.osgp.domain.core.valueobjects.smartmetering;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ScanMbusChannelsResponseData extends ActionResponse implements Serializable {
 
-    private static final long serialVersionUID = -7904676670230333481L;
+    private static final long serialVersionUID = -4198341767681440770L;
 
-    private String mbusIdentificationNumber1;
-    private String mbusIdentificationNumber2;
-    private String mbusIdentificationNumber3;
-    private String mbusIdentificationNumber4;
+    private final ArrayList<MbusChannelShortEquipmentIdentifier> channelShortIds = new ArrayList<>();
 
-    public ScanMbusChannelsResponseData(final String mbusIdentificationNumber1, final String mbusIdentificationNumber2,
-            final String mbusIdentificationNumber3, final String mbusIdentificationNumber4) {
-        this.mbusIdentificationNumber1 = mbusIdentificationNumber1;
-        this.mbusIdentificationNumber2 = mbusIdentificationNumber2;
-        this.mbusIdentificationNumber3 = mbusIdentificationNumber3;
-        this.mbusIdentificationNumber4 = mbusIdentificationNumber4;
+    public ScanMbusChannelsResponseData(final List<MbusChannelShortEquipmentIdentifier> channelShortIds) {
+        if (channelShortIds != null) {
+            this.channelShortIds.addAll(channelShortIds);
+        }
     }
 
-    public String getMbusIdentificationNumber1() {
-        return this.mbusIdentificationNumber1;
+    @Override
+    public String toString() {
+        return String.format("ScanMbusChannelsResponseData[channelShortIds=%s]", this.channelShortIds);
     }
 
-    public String getMbusIdentificationNumber2() {
-        return this.mbusIdentificationNumber2;
-    }
-
-    public String getMbusIdentificationNumber3() {
-        return this.mbusIdentificationNumber3;
-    }
-
-    public String getMbusIdentificationNumber4() {
-        return this.mbusIdentificationNumber4;
+    public List<MbusChannelShortEquipmentIdentifier> getChannelShortIds() {
+        return new ArrayList<>(this.channelShortIds);
     }
 
 }

--- a/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ScanMbusChannelsResponseData.java
+++ b/osgp-domain-core/src/main/java/com/alliander/osgp/domain/core/valueobjects/smartmetering/ScanMbusChannelsResponseData.java
@@ -15,7 +15,7 @@ public class ScanMbusChannelsResponseData extends ActionResponse implements Seri
 
     private static final long serialVersionUID = -4198341767681440770L;
 
-    private final ArrayList<MbusChannelShortEquipmentIdentifier> channelShortIds = new ArrayList<>();
+    private final List<MbusChannelShortEquipmentIdentifier> channelShortIds = new ArrayList<>();
 
     public ScanMbusChannelsResponseData(final List<MbusChannelShortEquipmentIdentifier> channelShortIds) {
         if (channelShortIds != null) {


### PR DESCRIPTION
On Scan M-Bus Channels all attributes identifying the M-Bus device per
channel should be returned. These are represented conform the M-Bus
Short Equipment Identifier (Short ID) attributes (Identification number,
Manufacturer identification, Version identification, Device type
identification).

* Adds MbusShortEquipmentIdentifier as value object for the M-Bus Short
  ID.
* Adds MbusChannelShortEquipmentIdentifier as value object for the M-Bus
  Short ID on a particular channel.
* Updates ScanMbusChannelsResponse to have a list of M-Bus Short IDs per
  channel instead of four M-Bus identification numbers.
* Updates the SmartMeteringAdhocEndpoint to return the list of Short IDs
  as result for scan M-Bus channels instead of the four identification
  numbers.