### PR TITLE
FLEX-4304 ~ Attempts to fix scenario Connection lost and reestablished.

### DIFF
--- a/osgp-adapter-domain-microgrids/src/main/java/com/alliander/osgp/adapter/domain/microgrids/application/config/CommunicationMonitoringConfig.java
+++ b/osgp-adapter-domain-microgrids/src/main/java/com/alliander/osgp/adapter/domain/microgrids/application/config/CommunicationMonitoringConfig.java
@@ -45,6 +45,7 @@ public class CommunicationMonitoringConfig extends AbstractConfig {
     private static final String PROPERTY_NAME_SCHEDULER_THREAD_NAME_PREFIX = "communication.monitoring.scheduler.thread.name.prefix";
     private static final String PROPERTY_NAME_MAXIMUM_TIME_WITHOUT_COMMUNICATION = "communication.monitoring.maximum.time.without.communication";
     private static final String PROPERTY_NAME_LAST_COMMUNICATION_UPDATE_INTERVAL = "communication.monitoring.last.communication.update.interval";
+    private static final String PROPERTY_NAME_INITIAL_DELAY = "communication.monitoring.initial.delay";
 
     private static final Boolean DEFAULT_COMMUNICATION_MONITORING_ENABLED = true;
     private static final Integer DEFAULT_MINIMUM_TIME_BETWEEN_RUNS = 2;
@@ -59,6 +60,9 @@ public class CommunicationMonitoringConfig extends AbstractConfig {
 
     // Default last communication update interval in seconds
     private static final Integer DEFAULT_LAST_COMMUNICATION_UPDATE_INTERVAL = 30;
+
+    // Default initial delay of 5 minutes
+    private static final Long DEFAULT_INITIAL_DELAY = 5L;
 
     @Resource
     private Environment environment;
@@ -132,6 +136,24 @@ public class CommunicationMonitoringConfig extends AbstractConfig {
         }
     }
 
+    @Bean
+    public Long initialDelay() {
+        LOGGER.info("Initializing Initial Delay bean.");
+        final String value = this.environment.getProperty(PROPERTY_NAME_INITIAL_DELAY);
+        if (StringUtils.isNotBlank(value) && StringUtils.isNumeric(value)) {
+            LOGGER.info("Using value {} for initial delay.", value);
+            final Long minutes = Long.parseLong(value);
+            return this.minutesToMilliseconds(minutes);
+        } else {
+            LOGGER.info("Using default value {} for initial delay.", DEFAULT_INITIAL_DELAY);
+            return this.minutesToMilliseconds(DEFAULT_INITIAL_DELAY);
+        }
+    }
+
+    private Long minutesToMilliseconds(final Long minutes) {
+        return minutes * 60 * 1000;
+    }
+
     private Boolean communicationMonitoringEnabled() {
         final String value = this.environment.getProperty(PROPERTY_NAME_COMMUNICATION_MONITORING_ENABLED);
         if (StringUtils.isNotBlank(value)) {
@@ -176,5 +198,4 @@ public class CommunicationMonitoringConfig extends AbstractConfig {
             return DEFAULT_THREAD_NAME_PREFIX;
         }
     }
-
 }

--- a/osgp-adapter-domain-microgrids/src/main/resources/osgp-adapter-domain-microgrids.properties
+++ b/osgp-adapter-domain-microgrids/src/main/resources/osgp-adapter-domain-microgrids.properties
@@ -31,6 +31,9 @@ communication.monitoring.maximum.time.without.communication=2
 # Configures the interval for updating the last communication time for the devices (time in seconds)
 #communication.monitoring.last.communication.update.interval=30
 
+# Configures the initial delay before the communication monitoring task will start (time in minutes)
+communication.monitoring.initial.delay=5
+
 # =========================================================
 # PERSISTENCE CONFIG 
 # =========================================================


### PR DESCRIPTION
- due to the random startup order of components, the task table can be
absent
- domain-adapter-microgrids uses the task table
- osgp-core creates the task table
- during nightly builds it seems that the domain component start about 3
minutes before osgp-core starts
- the initial delay added to the device communication monitoring task
prevents that the domain component uses the task table to soon