### PR TITLE
SLIM-1542 Manage firmware version data based on responses from a device

### DIFF
--- a/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/ConfigurationService.java
+++ b/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/ConfigurationService.java
@@ -650,6 +650,9 @@ public class ConfigurationService {
         this.webServiceResponseMessageSender.send(
                 responseMessage,
                 deviceMessageMetadata.getMessageType());
+
+        this.firmwareService.saveFirmwareVersionsReturnedFromDevice(deviceMessageMetadata.getDeviceIdentification(),
+                firmwareVersions);
     }
 
     public void requestUpdateFirmware(final DeviceMessageMetadata deviceMessageMetadata,

--- a/osgp-core/src/main/resources/db/migration/V20181003143231399__Adds_device_firmware_module.sql
+++ b/osgp-core/src/main/resources/db/migration/V20181003143231399__Adds_device_firmware_module.sql
@@ -1,0 +1,28 @@
+DO
+$$
+BEGIN
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_tables
+    WHERE  schemaname = current_schema
+    AND    tablename  = 'device_firmware_module') THEN
+
+    CREATE TABLE device_firmware_module (
+        device_id BIGINT NOT NULL REFERENCES device(id),
+        firmware_module_id BIGINT NOT NULL REFERENCES firmware_module(id),
+        module_version VARCHAR(100) NOT NULL,
+        CONSTRAINT device_firmware_module_pkey PRIMARY KEY (device_id, firmware_module_id)
+    );
+    -- Index on device_id should be covered by the PK on (device_id, firmware_module_id).
+    CREATE INDEX device_firmware_module_ix_firmware_module_id ON device_firmware_module (firmware_module_id);
+
+    ALTER TABLE device_firmware_module OWNER TO osp_admin;
+
+    GRANT ALL ON TABLE device_firmware_module TO osp_admin;
+    GRANT SELECT ON TABLE device_firmware_module TO osgp_read_only_ws_user;
+
+END IF;
+
+END;
+$$

--- a/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/DeviceFirmwareModule.java
+++ b/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/DeviceFirmwareModule.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.domain.core.entities;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+
+/**
+ * DeviceFirmwareModule entity class holds the module version of a firmware
+ * module known to be installed on a device.
+ */
+@Entity
+public class DeviceFirmwareModule implements Comparable<DeviceFirmwareModule>, Serializable {
+
+    private static final long serialVersionUID = -2836788496333802810L;
+
+    @Embeddable
+    public static class DeviceFirmwareModuleId implements Serializable {
+
+        private static final long serialVersionUID = -9004715010956854043L;
+
+        @Column
+        private Long deviceId;
+
+        @Column
+        private Long firmwareModuleId;
+
+        protected DeviceFirmwareModuleId() {
+            // No-argument constructor, not to be used by application code.
+        }
+
+        public DeviceFirmwareModuleId(final Long deviceId, final Long firmwareModuleId) {
+            this.deviceId = deviceId;
+            this.firmwareModuleId = firmwareModuleId;
+        }
+
+        public Long getDeviceId() {
+            return this.deviceId;
+        }
+
+        public Long getFirmwareModuleId() {
+            return this.firmwareModuleId;
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof DeviceFirmwareModuleId)) {
+                return false;
+            }
+            final DeviceFirmwareModuleId other = (DeviceFirmwareModuleId) obj;
+            return Objects.equals(this.deviceId, other.deviceId)
+                    && Objects.equals(this.firmwareModuleId, other.firmwareModuleId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.deviceId, this.firmwareModuleId);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[device=%s, module=%s]", this.deviceId, this.firmwareModuleId);
+        }
+    }
+
+    @EmbeddedId
+    private DeviceFirmwareModuleId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "device_id")
+    @MapsId("deviceId")
+    private Device device;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "firmware_module_id")
+    @MapsId("firmwareModuleId")
+    private FirmwareModule firmwareModule;
+
+    @Column(nullable = false)
+    private String moduleVersion;
+
+    protected DeviceFirmwareModule() {
+        // No-argument constructor, not to be used by application code.
+    }
+
+    public DeviceFirmwareModule(final Device device, final FirmwareModule firmwareModule, final String moduleVersion) {
+        this.device = device;
+        this.firmwareModule = firmwareModule;
+        this.id = new DeviceFirmwareModuleId(device.getId(), firmwareModule.getId());
+        this.moduleVersion = moduleVersion;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof DeviceFirmwareModule)) {
+            return false;
+        }
+        final DeviceFirmwareModule other = (DeviceFirmwareModule) obj;
+        return Objects.equals(this.device, other.device) && Objects.equals(this.firmwareModule, other.firmwareModule);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.device, this.firmwareModule);
+    }
+
+    @Override
+    public int compareTo(final DeviceFirmwareModule o) {
+        final int compareDevice = this.device.getDeviceIdentification().compareTo(o.device.getDeviceIdentification());
+        if (compareDevice != 0) {
+            return compareDevice;
+        }
+        final int compareFirmwareModule = this.firmwareModule.compareTo(o.firmwareModule);
+        if (compareFirmwareModule != 0) {
+            return compareFirmwareModule;
+        }
+        return this.moduleVersion.compareTo(o.moduleVersion);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DeviceFirmwareModule[device=%s, module=%s, version=%s]",
+                this.device.getDeviceIdentification(), this.firmwareModule.getDescription(), this.moduleVersion);
+    }
+
+    public void prepareForRemoval() {
+        this.device = null;
+        this.firmwareModule = null;
+    }
+
+    public final DeviceFirmwareModuleId getId() {
+        return this.id;
+    }
+
+    public Device getDevice() {
+        return this.device;
+    }
+
+    public FirmwareModule getFirmwareModule() {
+        return this.firmwareModule;
+    }
+
+    public String getModuleVersion() {
+        return this.moduleVersion;
+    }
+
+    public void setModuleVersion(final String moduleVersion) {
+        this.moduleVersion = moduleVersion;
+    }
+
+}

--- a/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/DeviceFirmwareModuleRepository.java
+++ b/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/DeviceFirmwareModuleRepository.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.domain.core.repositories;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.opensmartgridplatform.domain.core.entities.Device;
+import org.opensmartgridplatform.domain.core.entities.DeviceFirmwareModule;
+import org.opensmartgridplatform.domain.core.entities.DeviceFirmwareModule.DeviceFirmwareModuleId;
+import org.opensmartgridplatform.domain.core.entities.FirmwareModule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeviceFirmwareModuleRepository extends JpaRepository<DeviceFirmwareModule, DeviceFirmwareModuleId> {
+
+    @Query(value = "SELECT dfm FROM DeviceFirmwareModule dfm LEFT JOIN FETCH dfm.firmwareModule fm "
+            + "WHERE dfm.device = :device ORDER BY fm.description ASC")
+    List<DeviceFirmwareModule> findByDevice(@Param("device") Device device);
+
+    default Map<FirmwareModule, String> findVersionPerFirmwareModule(final Device device) {
+        return findByDevice(device).stream().collect(
+                Collectors.toMap(DeviceFirmwareModule::getFirmwareModule, DeviceFirmwareModule::getModuleVersion));
+    }
+
+}

--- a/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/DeviceRepository.java
+++ b/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/DeviceRepository.java
@@ -11,6 +11,10 @@ import java.net.InetAddress;
 import java.util.Date;
 import java.util.List;
 
+import org.opensmartgridplatform.domain.core.entities.Device;
+import org.opensmartgridplatform.domain.core.entities.DeviceModel;
+import org.opensmartgridplatform.domain.core.entities.Organisation;
+import org.opensmartgridplatform.domain.core.valueobjects.DeviceLifecycleStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,11 +24,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import org.opensmartgridplatform.domain.core.entities.Device;
-import org.opensmartgridplatform.domain.core.entities.DeviceModel;
-import org.opensmartgridplatform.domain.core.entities.Organisation;
-import org.opensmartgridplatform.domain.core.valueobjects.DeviceLifecycleStatus;
 
 @Repository
 @Transactional
@@ -37,6 +36,10 @@ public interface DeviceRepository extends JpaRepository<Device, Long>, JpaSpecif
             + "WHERE d.deviceIdentification = :deviceIdentification")
     Device findByDeviceIdentificationWithFirmware(@Param("deviceIdentification") String deviceIdentification);
 
+    @Query("SELECT d FROM Device d LEFT JOIN FETCH d.deviceFirmwareModules dfm LEFT JOIN FETCH dfm.firmwareModule fm "
+            + "WHERE d.deviceIdentification = :deviceIdentification")
+    Device findByDeviceIdentificationWithFirmwareModules(@Param("deviceIdentification") String deviceIdentification);
+
     List<Device> findByNetworkAddress(InetAddress address);
 
     @Query("SELECT d " + "FROM Device d " + "WHERE EXISTS " + "(" + "	SELECT auth.id "
@@ -45,7 +48,8 @@ public interface DeviceRepository extends JpaRepository<Device, Long>, JpaSpecif
 
     @Query("SELECT d " + "FROM Device d " + "WHERE NOT EXISTS " + "(" + "	SELECT auth.id "
             + "	FROM d.authorizations auth "
-            + "	WHERE auth.functionGroup = org.opensmartgridplatform.domain.core.valueobjects.DeviceFunctionGroup.OWNER" + ")")
+            + "	WHERE auth.functionGroup = org.opensmartgridplatform.domain.core.valueobjects.DeviceFunctionGroup.OWNER"
+            + ")")
     List<Device> findDevicesWithNoOwner();
 
     @Query("SELECT d " + "FROM Device d " + "WHERE EXISTS " + "(" + "	SELECT auth.id "

--- a/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/FirmwareModuleRepository.java
+++ b/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/FirmwareModuleRepository.java
@@ -15,5 +15,5 @@ import org.opensmartgridplatform.domain.core.entities.FirmwareModule;
 @Repository
 public interface FirmwareModuleRepository extends JpaRepository<FirmwareModule, Long> {
 
-    FirmwareModule findByDescription(String description);
+    FirmwareModule findByDescriptionIgnoreCase(String description);
 }

--- a/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/FirmwareModuleData.java
+++ b/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/FirmwareModuleData.java
@@ -135,7 +135,7 @@ public class FirmwareModuleData implements Serializable {
             final FirmwareModuleRepository firmwareModuleRepository, final String moduleVersion,
             final String moduleDescription) {
         if (!StringUtils.isEmpty(moduleVersion)) {
-            versionsByModule.put(firmwareModuleRepository.findByDescription(moduleDescription), moduleVersion);
+            versionsByModule.put(firmwareModuleRepository.findByDescriptionIgnoreCase(moduleDescription), moduleVersion);
         }
     }
 }


### PR DESCRIPTION
Adds table device_firmware_module to osgp_core to have a place to store
information about versions of firmware modules that are known to be
active on a device.

Updates code where firmware module versions as retrieved from a device
are handled, to store these versions in the database.